### PR TITLE
bugfix: #20 修复redis最新版本不兼容redis-py-cluster的问题，redis版本号升级到2.10.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ requests==2.20.0
 celery==3.1.18
 kombu==3.0.35
 django-celery==3.1.16
-redis==2.10.5
 httplib2==0.9.1
 Mako==1.0.4
 MarkupSafe==0.23
@@ -25,4 +24,5 @@ django-nose==1.4.5
 # pipeline
 ujson==1.35
 pyparsing==2.2.0
+redis==2.10.6
 redis-py-cluster==1.3.5


### PR DESCRIPTION
- bug fix
    - 修复redis最新版本不兼容redis-py-cluster的问题，redis版本号升级到2.10.6
