### PR TITLE
improvement: 标准插件Tag表单支持changeHook方法 #81

### DIFF
--- a/pipeline/blueflow/src/components/common/RenderForm/FormItem.vue
+++ b/pipeline/blueflow/src/components/common/RenderForm/FormItem.vue
@@ -333,7 +333,7 @@ export default {
             }
         }
     }
-    &.show-label .rf-tag-form {
+    &.show-label > .rf-tag-form {
         margin-left: 120px;
     }
     .rf-tag-hook {

--- a/pipeline/blueflow/src/components/common/RenderForm/FormItem.vue
+++ b/pipeline/blueflow/src/components/common/RenderForm/FormItem.vue
@@ -10,7 +10,16 @@
 * specific language governing permissions and limitations under the License.
 */
 <template>
-    <div :class="['rf-form-item', 'clearfix', {'rf-has-hook': showHook}]" v-show="showForm">
+    <div
+        :class="[
+            'rf-form-item',
+            'clearfix',
+            {
+                'rf-has-hook': showHook,
+                'show-label': option.showLabel
+            }
+        ]"
+        v-show="showForm">
         <div v-if="!hook && option.showGroup && scheme.attrs.name" class="rf-group-name">
             <h3 class="name">{{scheme.attrs.name}}</h3>
             <div v-if="scheme.attrs.desc" class="rf-group-desc">
@@ -22,11 +31,11 @@
             :class="['rf-tag-label', {'required': isRequired()}]">
             {{scheme.attrs.name}}
         </label>
-        <div v-if="hook" class="rf-tag-form">
+        <div v-show="hook" class="rf-tag-form">
             <el-input :disabled="true" :value="String(value)"></el-input>
         </div>
         <component
-            v-else
+            v-show="!hook"
             class="rf-tag-form"
             ref="tagComponent"
             :is="tagComponent"
@@ -324,7 +333,7 @@ export default {
             }
         }
     }
-    .rf-tag-label + .rf-tag-form {
+    &.show-label .rf-tag-form {
         margin-left: 120px;
     }
     .rf-tag-hook {

--- a/pipeline/blueflow/src/components/common/RenderForm/formMixins.js
+++ b/pipeline/blueflow/src/components/common/RenderForm/formMixins.js
@@ -223,7 +223,11 @@ export function getFormMixins (attrs = {}) {
                 this.$emit('onShow')
             },
             hide () {
+                this.changeHook(false)
                 this.$emit('onHide')
+            },
+            changeHook (val) {
+                this.$parent.onHookForm(val)
             },
             // 获取 form 项实例
             get_form_instance () {

--- a/pipeline/blueflow/src/pages/template/TemplateEdit/NodeConfig.vue
+++ b/pipeline/blueflow/src/pages/template/TemplateEdit/NodeConfig.vue
@@ -957,6 +957,10 @@ export default {
             } else {  // cancel hook
                 variableKey = this.inputAtomData[key] // variable key
                 const variable = this.constants[variableKey]
+                if (!variable) {
+                    return
+                }
+
                 const formKey = this.isSingleAtom ? tagCode : key // input arguments form item key
                 this.inputAtomHook[formKey] = val
                 this.inputAtomData[formKey] = tools.deepClone(this.constants[variableKey].value)


### PR DESCRIPTION
- 新功能
    - 无
- 优化项
    - 任务节点在编辑输入参数时，当参数勾选为全局变量后，在标准插件配置项定义的事件回调里，支持调用 changeHook 方法来去掉对应表单的勾选状态
- bug fix
    - 无

close #81 