### PR TITLE
bugfix: 修复图片引用路径的问题 #83

### DIFF
--- a/pipeline/blueflow/builds/webpack.base.js
+++ b/pipeline/blueflow/builds/webpack.base.js
@@ -109,7 +109,7 @@ module.exports = {
                 loader: 'url-loader',
                 options: {
                     limit: 10000,
-                    name: path.posix.join('/images/[name].[ext]')
+                    name: path.posix.join('images/[name].[ext]')
                 }
             },
             {


### PR DESCRIPTION
- 新功能
    - 无
- 优化项
    - 无
- bug fix
    - 修复 webpack 配置图片引用路径错误，导致图片加载失败的问题

close #83 
