### PR TITLE
bugfix:锁定webpack版本，解决部分版本webpack无法动态导入vue组件的问题 #103

### DIFF
--- a/pipeline/blueflow/package.json
+++ b/pipeline/blueflow/package.json
@@ -59,7 +59,7 @@
     "vue-json-pretty": "^1.4.1-beta.1",
     "vue-loader": "^15.2.4",
     "vue-template-compiler": "^2.5.16",
-    "webpack": "^4.28.4",
+    "webpack": "4.28.4",
     "webpack-cli": "^3.0.3",
     "webpack-dev-server": "^3.2.1",
     "webpack-merge": "^4.1.2",


### PR DESCRIPTION
- 新功能
    - 无
- 优化项
    - 无
- bug fix
    - 更新 webpack 版本到4.29.0及以上版本后，代码构建失败问题修复。

close #103 
