### PR TITLE
bugfix: 修复新版 IP 选择器同时拥有筛选条件和过滤条件时返回 IP 为空的问题 #229

### DIFF
--- a/pipeline_plugins/cmdb_ip_picker/utils.py
+++ b/pipeline_plugins/cmdb_ip_picker/utils.py
@@ -79,7 +79,7 @@ def get_ip_picker_result(username, bk_biz_id, bk_supplier_account, kwargs):
             filters_dct.setdefault(ft['field'], [])
             filters_dct[ft['field']] += format_condition_value(ft['value'])
         new_topo_tree = process_topo_tree_by_condition(biz_topo_tree, filters_dct)
-        filter_host = filters_dct.pop('host', [])
+        filter_host = set(filters_dct.pop('host', []))
         # 把拓扑筛选条件转换成 modules 筛选条件
         filter_modules = get_modules_by_condition(new_topo_tree, filters_dct)
         filter_modules_id = get_modules_id(filter_modules)
@@ -95,7 +95,7 @@ def get_ip_picker_result(username, bk_biz_id, bk_supplier_account, kwargs):
             excludes_dct.setdefault(ex['field'], [])
             excludes_dct[ex['field']] += format_condition_value(ex['value'])
         new_topo_tree = process_topo_tree_by_condition(biz_topo_tree, excludes_dct)
-        exclude_host = excludes_dct.pop('host', [])
+        exclude_host = set(excludes_dct.pop('host', []))
         # 把拓扑排除条件转换成 modules 排除条件
         exclude_modules = [] if not excludes_dct else get_modules_by_condition(new_topo_tree, excludes_dct)
         exclude_modules_id = get_modules_id(exclude_modules)

--- a/pipeline_plugins/cmdb_ip_picker/utils.py
+++ b/pipeline_plugins/cmdb_ip_picker/utils.py
@@ -79,11 +79,13 @@ def get_ip_picker_result(username, bk_biz_id, bk_supplier_account, kwargs):
             filters_dct.setdefault(ft['field'], [])
             filters_dct[ft['field']] += format_condition_value(ft['value'])
         new_topo_tree = process_topo_tree_by_condition(biz_topo_tree, filters_dct)
+        filter_host = filters_dct.pop('host', [])
+        # 把拓扑筛选条件转换成 modules 筛选条件
         filter_modules = get_modules_by_condition(new_topo_tree, filters_dct)
         filter_modules_id = get_modules_id(filter_modules)
         data = [host for host in data if set(host['host_modules_id']) & set(filter_modules_id)]
-        if 'host' in filters_dct:
-            data = [host for host in data if host['bk_host_innerip'] in filters_dct['host']]
+        if filter_host:
+            data = [host for host in data if host['bk_host_innerip'] in filter_host]
 
     # 过滤条件
     excludes = kwargs['excludes']
@@ -93,11 +95,13 @@ def get_ip_picker_result(username, bk_biz_id, bk_supplier_account, kwargs):
             excludes_dct.setdefault(ex['field'], [])
             excludes_dct[ex['field']] += format_condition_value(ex['value'])
         new_topo_tree = process_topo_tree_by_condition(biz_topo_tree, excludes_dct)
-        exclude_modules = get_modules_by_condition(new_topo_tree, excludes_dct)
+        exclude_host = excludes_dct.pop('host', [])
+        # 把拓扑排除条件转换成 modules 排除条件
+        exclude_modules = [] if not excludes_dct else get_modules_by_condition(new_topo_tree, excludes_dct)
         exclude_modules_id = get_modules_id(exclude_modules)
-        data = [host for host in data if not set(host['host_modules_id']) & set(exclude_modules_id)]
-        if 'host' in excludes_dct:
-            data = [host for host in data if host['bk_host_innerip'] not in excludes_dct['host']]
+        data = [host for host in data if not (set(host['host_modules_id']) & set(exclude_modules_id))]
+        if exclude_host:
+            data = [host for host in data if host['bk_host_innerip'] not in exclude_host]
 
     result = {
         'result': True,
@@ -205,7 +209,7 @@ def get_modules_id(modules):
 
 def process_topo_tree_by_condition(topo_tree, condition):
     """
-    @summary: 根据过滤条件保留或者排除空闲机模块
+    @summary: 根据过滤条件保留或者排除空闲机池
     @param topo_tree:
     @param condition:
     @return:

--- a/pipeline_plugins/tests/cmdb_ip_picker/test_utils.py
+++ b/pipeline_plugins/tests/cmdb_ip_picker/test_utils.py
@@ -20,15 +20,22 @@ from pipeline_plugins.cmdb_ip_picker.utils import (
     get_objects_of_topo_tree,
     get_cmdb_topo_tree,
     process_topo_tree_by_condition,
-    format_condition_value
+    format_condition_value,
+    build_cmdb_search_host_kwargs,
+    get_ip_picker_result
 )
 
 
 from pipeline_plugins.tests.utils import mock_get_client_by_user
 
+mock_get_client_by_user.success = True
+
 
 class TestGetObjects(TestCase):
     def setUp(self):
+        self.username = 'admin'
+        self.bk_biz_id = '2'
+        self.bk_supplier_account = 0
         self.topo_tree = {
             "default": 0,
             "bk_obj_name": u"业务",
@@ -239,6 +246,285 @@ class TestGetObjects(TestCase):
 
     @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
     def test_get_cmdb_topo_tree(self):
-        mock_get_client_by_user.success = True
         topo_tree = get_cmdb_topo_tree('admin', '2', '')
-        self.assertEquals(topo_tree['result'], True)
+        self.assertTrue(topo_tree['result'])
+        self.assertEquals(topo_tree['data'][0], self.topo_tree)
+
+    @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
+    def test_get_ip_picker_result__boundary_value(self):
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [],
+            'ip': [],
+            'filters': [],
+            'excludes': [],
+        }
+        self.assertFalse(
+            get_ip_picker_result(self.username,
+                                 self.bk_biz_id,
+                                 self.bk_supplier_account,
+                                 topo_kwargs)['result']
+        )
+
+    @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
+    def test_get_ip_picker_result__selector_topo(self):
+        mock_get_client_by_user.success = True
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [
+                {'bk_obj_id': 'set', 'bk_inst_id': 2},
+            ],
+            'ip': [],
+            'filters': [],
+            'excludes': [],
+        }
+        ip_data = get_ip_picker_result(self.username,
+                                       self.bk_biz_id,
+                                       self.bk_supplier_account,
+                                       topo_kwargs)['data']
+        ip = [host['bk_host_innerip'] for host in ip_data]
+        self.assertEquals(ip, ['1.1.1.1'])
+
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [
+                {'bk_obj_id': 'set', 'bk_inst_id': 3},
+                {'bk_obj_id': 'module', 'bk_inst_id': 5},
+            ],
+            'ip': [],
+            'filters': [],
+            'excludes': [],
+        }
+        ip_data = get_ip_picker_result(self.username,
+                                       self.bk_biz_id,
+                                       self.bk_supplier_account,
+                                       topo_kwargs)['data']
+        ip = [host['bk_host_innerip'] for host in ip_data]
+        self.assertEquals(ip, ['2.2.2.2'])
+
+    @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
+    def test_get_ip_picker_result__selector_ip(self):
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['ip'],
+            'topo': [],
+            'ip': [
+                {
+                    'bk_host_name': 'host1',
+                    'bk_host_id': 2,
+                    'agent': 1,
+                    'cloud': [
+                        {
+                            'bk_obj_name': '',
+                            'id': '0',
+                            'bk_obj_id': 'plat',
+                            'bk_obj_icon': '',
+                            'bk_inst_id': 0,
+                            'bk_inst_name': 'default area'
+                        }
+                    ],
+                    'bk_host_innerip': '1.1.1.1'
+                },
+                {
+                    'bk_host_name': 'host2',
+                    'bk_host_id': 2,
+                    'agent': 1,
+                    'cloud': [
+                        {
+                            'bk_obj_name': '',
+                            'id': '0',
+                            'bk_obj_id': 'plat',
+                            'bk_obj_icon': '',
+                            'bk_inst_id': 0,
+                            'bk_inst_name': 'default area'
+                        }
+                    ],
+                    'bk_host_innerip': '2.2.2.2'
+                }
+            ],
+            'filters': [],
+            'excludes': [],
+        }
+        ip_data = get_ip_picker_result(self.username,
+                                       self.bk_biz_id,
+                                       self.bk_supplier_account,
+                                       topo_kwargs)['data']
+        ip = [host['bk_host_innerip'] for host in ip_data]
+        self.assertEquals(ip, ['1.1.1.1', '2.2.2.2'])
+
+    @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
+    def test_get_ip_picker_result__filters(self):
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [
+                {'bk_obj_id': 'biz', 'bk_inst_id': 2},
+            ],
+            'ip': [],
+            'filters': [
+                {'field': 'set', 'value': ['set2']}
+            ],
+            'excludes': [],
+        }
+        ip_data = get_ip_picker_result(self.username,
+                                       self.bk_biz_id,
+                                       self.bk_supplier_account,
+                                       topo_kwargs)['data']
+        ip = [host['bk_host_innerip'] for host in ip_data]
+        self.assertEquals(ip, ['2.2.2.2'])
+
+    @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
+    def test_get_ip_picker_result__excludes(self):
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [
+                {'bk_obj_id': 'biz', 'bk_inst_id': 2},
+            ],
+            'ip': [],
+            'filters': [],
+            'excludes': [
+                {'field': 'set', 'value': ['set2']}
+            ],
+        }
+        ip_data = get_ip_picker_result(self.username,
+                                       self.bk_biz_id,
+                                       self.bk_supplier_account,
+                                       topo_kwargs)['data']
+        ip = [host['bk_host_innerip'] for host in ip_data]
+        self.assertEquals(ip, ['1.1.1.1'])
+
+    def test_build_cmdb_search_host_kwargs__boundary_value(self):
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [],
+            'ip': [],
+            'filters': [],
+            'excludes': [],
+        }
+        self.assertFalse(
+            build_cmdb_search_host_kwargs(self.bk_biz_id,
+                                          self.bk_supplier_account,
+                                          topo_kwargs,
+                                          self.topo_tree)['result']
+        )
+
+        ip_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['ip'],
+            'topo': [],
+            'ip': [],
+            'filters': [],
+            'excludes': [],
+        }
+        self.assertFalse(
+            build_cmdb_search_host_kwargs(self.bk_biz_id,
+                                          self.bk_supplier_account,
+                                          ip_kwargs,
+                                          self.topo_tree)['result']
+        )
+
+    def test_build_cmdb_search_host_kwargs__selector_topo(self):
+        topo_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['topo'],
+            'topo': [
+                {'bk_obj_id': 'set', 'bk_inst_id': 3},
+                {'bk_obj_id': 'module', 'bk_inst_id': 8},
+            ],
+            'ip': [],
+            'filters': [],
+            'excludes': [],
+        }
+        self.assertEquals(
+            build_cmdb_search_host_kwargs(self.bk_biz_id,
+                                          self.bk_supplier_account,
+                                          topo_kwargs,
+                                          self.topo_tree)['data'],
+            {
+                'bk_biz_id': '2',
+                'bk_supplier_account': 0,
+                'condition': [{
+                    'bk_obj_id': 'module',
+                    'fields': ['bk_module_id', 'bk_module_name'],
+                    'condition': [{
+                        'field': 'bk_module_id',
+                        'operator': '$in',
+                        'value': [5, 6, 7, 8]
+                    }]
+                }]
+            }
+        )
+
+    def test_build_cmdb_search_host_kwargs__selector_ip(self):
+        ip_kwargs = {
+            'bk_biz_id': self.bk_biz_id,
+            'selectors': ['ip'],
+            'topo': [],
+            'ip': [
+                {
+                    'bk_host_name': 'host1',
+                    'bk_host_id': 2,
+                    'agent': 1,
+                    'cloud': [
+                        {
+                            'bk_obj_name': '',
+                            'id': '0',
+                            'bk_obj_id': 'plat',
+                            'bk_obj_icon': '',
+                            'bk_inst_id': 0,
+                            'bk_inst_name': 'default area'
+                        }
+                    ],
+                    'bk_host_innerip': '1.1.1.1'
+                },
+                {
+                    'bk_host_name': 'host2',
+                    'bk_host_id': 2,
+                    'agent': 1,
+                    'cloud': [
+                        {
+                            'bk_obj_name': '',
+                            'id': '0',
+                            'bk_obj_id': 'plat',
+                            'bk_obj_icon': '',
+                            'bk_inst_id': 0,
+                            'bk_inst_name': 'default area'
+                        }
+                    ],
+                    'bk_host_innerip': '2.2.2.2'
+                }
+            ],
+            'filters': [],
+            'excludes': [],
+        }
+        self.assertEquals(
+            build_cmdb_search_host_kwargs(self.bk_biz_id,
+                                          self.bk_supplier_account,
+                                          ip_kwargs,
+                                          self.topo_tree)['data'],
+            {
+                'bk_biz_id': '2',
+                'bk_supplier_account': 0,
+                'condition': [
+                    {
+                        'bk_obj_id': 'module',
+                        'fields': ['bk_module_id', 'bk_module_name'],
+                        'condition': []
+                    },
+                    {
+                        'bk_obj_id': 'host',
+                        'fields': ['bk_host_id', 'bk_host_innerip', 'bk_host_outerip', 'bk_host_name'],
+                        'condition': [{
+                            'field': 'bk_host_innerip',
+                            'operator': '$in',
+                            'value': ['1.1.1.1', '2.2.2.2']
+                        }]
+                    }
+                ]
+            }
+        )

--- a/pipeline_plugins/tests/cmdb_ip_picker/test_utils.py
+++ b/pipeline_plugins/tests/cmdb_ip_picker/test_utils.py
@@ -28,8 +28,6 @@ from pipeline_plugins.cmdb_ip_picker.utils import (
 
 from pipeline_plugins.tests.utils import mock_get_client_by_user
 
-mock_get_client_by_user.success = True
-
 
 class TestGetObjects(TestCase):
     def setUp(self):
@@ -246,12 +244,14 @@ class TestGetObjects(TestCase):
 
     @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
     def test_get_cmdb_topo_tree(self):
+        mock_get_client_by_user.success = True
         topo_tree = get_cmdb_topo_tree('admin', '2', '')
         self.assertTrue(topo_tree['result'])
         self.assertEquals(topo_tree['data'][0], self.topo_tree)
 
     @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
     def test_get_ip_picker_result__boundary_value(self):
+        mock_get_client_by_user.success = True
         topo_kwargs = {
             'bk_biz_id': self.bk_biz_id,
             'selectors': ['topo'],
@@ -307,6 +307,7 @@ class TestGetObjects(TestCase):
 
     @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
     def test_get_ip_picker_result__selector_ip(self):
+        mock_get_client_by_user.success = True
         topo_kwargs = {
             'bk_biz_id': self.bk_biz_id,
             'selectors': ['ip'],
@@ -357,6 +358,7 @@ class TestGetObjects(TestCase):
 
     @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
     def test_get_ip_picker_result__filters(self):
+        mock_get_client_by_user.success = True
         topo_kwargs = {
             'bk_biz_id': self.bk_biz_id,
             'selectors': ['topo'],
@@ -378,6 +380,7 @@ class TestGetObjects(TestCase):
 
     @patch('pipeline_plugins.cmdb_ip_picker.utils.get_client_by_user', mock_get_client_by_user)
     def test_get_ip_picker_result__excludes(self):
+        mock_get_client_by_user.success = True
         topo_kwargs = {
             'bk_biz_id': self.bk_biz_id,
             'selectors': ['topo'],

--- a/pipeline_plugins/tests/utils.py
+++ b/pipeline_plugins/tests/utils.py
@@ -193,33 +193,67 @@ def mock_get_client_by_user(username):
             }
 
         def search_host(self, kwargs):
+            info = [
+                {
+                    'host': {
+                        'bk_host_innerip': '1.1.1.1',
+                        'bk_host_outerip': '1.1.1.1',
+                        'bk_host_name': '1.1.1.1',
+                        'bk_host_id': 1,
+                        'bk_cloud_id': [{
+                            'bk_obj_name': '',
+                            'id': '0',
+                            'bk_obj_id': 'plat',
+                            'bk_obj_icon': '',
+                            'bk_inst_id': 0,
+                            'bk_inst_name': 'default area'
+                        }]
+                    },
+                    'module': [
+                        {
+                            'bk_module_id': 3,
+                            'bk_module_name': u"空闲机"
+                        }
+                    ]
+                },
+                {
+                    'host': {
+                        'bk_host_innerip': '2.2.2.2',
+                        'bk_host_outerip': '2.2.2.2',
+                        'bk_host_name': '2.2.2.2',
+                        'bk_host_id': 1,
+                        'bk_cloud_id': [{
+                            'bk_obj_name': '',
+                            'id': '0',
+                            'bk_obj_id': 'plat',
+                            'bk_obj_icon': '',
+                            'bk_inst_id': 0,
+                            'bk_inst_name': 'default area'
+                        }]
+                    },
+                    'module': [
+                        {
+                            'bk_module_id': 5,
+                            'bk_module_name': 'test1'
+                        }
+                    ]
+                }
+            ]
+            if kwargs.get('condition', []):
+                for cond in kwargs['condition']:
+                    if cond['bk_obj_id'] == 'module' and cond.get('condition') \
+                            and cond['condition'][0]['operator'] == '$in':
+                        in_module = set(cond['condition'][0]['value'])
+                        info = [host for host in info
+                                if (set([mod['bk_module_id'] for mod in host['module']]) & in_module)]
+                    if cond['bk_obj_id'] == 'host' and cond.get('condition') \
+                            and cond['condition'][0]['operator'] == '$in':
+                        in_host = cond['condition'][0]['value']
+                        info = [host for host in info if host['host']['bk_host_innerip'] in in_host]
             return {
                 'result': self.success,
                 'data': {
-                    'info': [
-                        {
-                            'host': {
-                                'bk_host_innerip': '1.0.0.1',
-                                'bk_host_outerip': '1.0.0.1',
-                                'bk_host_name': '1.0.0.1',
-                                'bk_host_id': 1,
-                                'bk_cloud_id': {
-                                    'bk_obj_name': '',
-                                    'id': '0',
-                                    'bk_obj_id': 'plat',
-                                    'bk_obj_icon': '',
-                                    'bk_inst_id': 0,
-                                    'bk_inst_name': 'default area'
-                                }
-                            },
-                            'module': [
-                                {
-                                    'bk_module_id': 2,
-                                    'bk_module_name': 'test2'
-                                }
-                            ]
-                        },
-                    ]
+                    'info': info
                 },
                 'message': 'error'
             }


### PR DESCRIPTION
- bug fix
    - 修复新版 IP 选择器同时拥有筛选条件和过滤条件时返回 IP 为空的问题
close #229
