### PR TITLE
improvement:  ip选择器错误提示和排除条件为空时文案优化

### DIFF
--- a/frontend/desktop/src/components/common/RenderForm/IpSelector/SelectCondition.vue
+++ b/frontend/desktop/src/components/common/RenderForm/IpSelector/SelectCondition.vue
@@ -29,7 +29,7 @@
                 </condition-item>
             </div>
         </template>
-        <div v-else class="condition-empty" @click.stop="addCondition">{{i18n.addItem}}</div>
+        <div v-else class="condition-empty" @click.stop="addCondition">{{i18n.addItem + label}}</div>
     </div>
 </template>
 <script>
@@ -39,7 +39,7 @@
 
     const i18n = {
         allSatisfy: gettext('（同时满足）'),
-        addItem: gettext('增加一条筛选条件')
+        addItem: gettext('增加一条')
     }
 
     export default {

--- a/frontend/desktop/src/components/common/RenderForm/IpSelector/StaticIp.vue
+++ b/frontend/desktop/src/components/common/RenderForm/IpSelector/StaticIp.vue
@@ -266,6 +266,7 @@
                     return true
                 } else {
                     this.dataError = true
+                    this.onAddIpCancel()
                     return false
                 }
             }

--- a/frontend/desktop/src/components/common/RenderForm/IpSelector/StaticIpAddingPanel.vue
+++ b/frontend/desktop/src/components/common/RenderForm/IpSelector/StaticIpAddingPanel.vue
@@ -12,7 +12,11 @@
 <template>
     <div class="static-ip-adding-panel">
         <div class="ip-added-number">{{i18n.add}}({{selectedIp.length}})</div>
-        <div class="search-area">
+        <div class="operation-area">
+            <div class="ip-list-add">
+                <bk-button type="primary" size="mini" @click.stop="onAddIpConfirm">{{i18n.add}}</bk-button>
+                <bk-button type="default" size="mini" @click.stop="onAddIpCancel">{{i18n.cancel}}</bk-button>
+            </div>
             <ip-search-input class="ip-search-wrap" @search="onIpSearch"></ip-search-input>
         </div>
         <div class="ip-list-table-wrap">
@@ -61,10 +65,6 @@
                     @page-change="onPageChange">
                 </bk-paging>
             </div>
-        </div>
-        <div class="ip-list-add">
-            <bk-button type="primary" size="mini" @click.stop="onAddIpConfirm">{{i18n.add}}</bk-button>
-            <bk-button type="default" size="mini" @click.stop="onAddIpCancel">{{i18n.cancel}}</bk-button>
         </div>
     </div>
 </template>
@@ -184,14 +184,16 @@
     color: #313238;
     border-bottom: 1px solid #dcdee5;
 }
-.search-area {
+.operation-area {
     position: relative;
-    height: 76px;
+    .ip-list-add {
+        margin: 24px 0;
+    }
     .ip-search-wrap {
         position: absolute;
-        top: 20px;
+        top: -6px;
         right: 0;
-        width: 80%;
+        width: 70%;
     }
 }
 .ip-table {
@@ -268,9 +270,6 @@
             }
         }
     }
-}
-.ip-list-add {
-    margin-top: 10px;
 }
 .table-pagination {
     margin-top: 20px;

--- a/frontend/desktop/src/components/common/RenderForm/IpSelector/StaticIpAddingPanel.vue
+++ b/frontend/desktop/src/components/common/RenderForm/IpSelector/StaticIpAddingPanel.vue
@@ -14,8 +14,8 @@
         <div class="ip-added-number">{{i18n.add}}({{selectedIp.length}})</div>
         <div class="operation-area">
             <div class="ip-list-add">
-                <bk-button type="primary" size="mini" @click.stop="onAddIpConfirm">{{i18n.add}}</bk-button>
-                <bk-button type="default" size="mini" @click.stop="onAddIpCancel">{{i18n.cancel}}</bk-button>
+                <bk-button type="primary" @click.stop="onAddIpConfirm">{{i18n.add}}</bk-button>
+                <bk-button type="default" @click.stop="onAddIpCancel">{{i18n.cancel}}</bk-button>
             </div>
             <ip-search-input class="ip-search-wrap" @search="onIpSearch"></ip-search-input>
         </div>
@@ -191,9 +191,13 @@
     }
     .ip-search-wrap {
         position: absolute;
-        top: -6px;
+        top: -2px;
         right: 0;
         width: 70%;
+    }
+    .bk-button {
+        height: 32px;
+        line-height: 32px;
     }
 }
 .ip-table {

--- a/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/VariableEditDialog.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/VariableEditDialog.vue
@@ -19,13 +19,17 @@
             :is-show.sync="isShow"
             @confirm="onConfirm"
             @cancel="onCancel">
-            <div slot="content">
+            <div slot="content" class="variable-params-content">
                 <RenderForm
                     ref="renderForm"
                     :scheme="renderConfig"
                     :form-option="renderOption"
-                    v-model="formData">
+                    v-model="formData"
+                    @change="onDataChange">
                 </RenderForm>
+                <div class="error-tips" v-if="formError">
+                    <span class="common-error-tip error-info">{{i18n.checkData}}</span>
+                </div>
             </div>
         </bk-dialog>
     </div>
@@ -42,10 +46,12 @@
         props: ['isShow', 'renderConfig', 'renderData', 'renderOption'],
         data () {
             return {
+                formData: tools.deepClone(this.renderData),
+                formError: false,
                 i18n: {
-                    edit: gettext('编辑变量')
-                },
-                formData: tools.deepClone(this.renderData)
+                    edit: gettext('编辑变量'),
+                    checkData: gettext('请检查变量参数是否合法')
+                }
             }
         },
         methods: {
@@ -54,23 +60,36 @@
                 if (this.$refs.renderForm) {
                     formValid = this.$refs.renderForm.validate()
                 }
-                if (!formValid) return
+                if (!formValid) {
+                    this.formError = true
+                    return
+                }
                 this.$emit('onConfirmDialogEdit', this.formData)
             },
             onCancel () {
                 this.$emit('onCancelDialogEdit')
+            },
+            onDataChange () {
+                this.formError = false
             }
         }
     }
 </script>
 <style lang="scss" scoped>
 .edit-dialog-wrapper {
+    position: relative;
     /deep/ .tag-form {
         margin-left: 0;
     }
     /deep/ .bk-dialog-body {
         max-height: 360px;
         overflow-y: auto;
+    }
+    .error-tips {
+        position: absolute;
+        bottom: 18px;
+        right: 230px;
+        font-size: 12px;
     }
 }
 </style>

--- a/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/VariableEditDialog.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/VariableEditDialog.vue
@@ -50,7 +50,7 @@
                 formError: false,
                 i18n: {
                     edit: gettext('编辑变量'),
-                    checkData: gettext('请检查变量参数是否合法')
+                    checkData: gettext('变量的参数值不合法')
                 }
             }
         },


### PR DESCRIPTION
- 优化项
    - 排除条件中提示是“增加一条筛选条件”改为“增加一条排除条件”
    - 添加静态 ip 的确定、取消按钮位置放到表格头部
    - 表单校验时，静态 ip 为空，跳转到静态 ip 列表

close #298 