### PR TITLE
improvement:去除部分选择器的搜索框和优化时间维度选择器顺序

### DIFF
--- a/frontend/desktop/src/pages/admin/statistics/Instance/index.vue
+++ b/frontend/desktop/src/pages/admin/statistics/Instance/index.vue
@@ -84,21 +84,6 @@
                 <div class="content-title">{{i18n.instanceTime}}</div>
                 <div class="content-task-instance">
                     <div class="content-instance-time">
-                        <!--时间维度选择-->
-                        <bk-selector
-                            :list="taskDimensionArray"
-                            :display-key="'name'"
-                            :setting-name="'value'"
-                            :search-key="'name'"
-                            :setting-key="'value'"
-                            :selected.sync="choiceDate"
-                            :placeholder="i18n.choice"
-                            :searchable="true"
-                            :allow-clear="true"
-                            @item-selected="onChangeTimeType">
-                        </bk-selector>
-                    </div>
-                    <div class="content-instance-time">
                         <!--业务选择-->
                         <bk-selector
                             :list="businessList"
@@ -137,6 +122,20 @@
                             @change="onInstanceTime">
                         </bk-date-range>
                         <i :class="['bk-icon icon-angle-down',{ 'icon-flip': choiceDownShow }]"></i>
+                    </div>
+                    <div class="content-instance-time date-scope">
+                        <!--时间维度选择-->
+                        <bk-selector
+                            :list="taskDimensionArray"
+                            :display-key="'name'"
+                            :setting-name="'value'"
+                            :search-key="'name'"
+                            :setting-key="'value'"
+                            :selected.sync="choiceDate"
+                            :placeholder="i18n.choice"
+                            :allow-clear="true"
+                            @item-selected="onChangeTimeType">
+                        </bk-selector>
                     </div>
                 </div>
             </div>

--- a/frontend/desktop/src/pages/periodic/PeriodicList/index.vue
+++ b/frontend/desktop/src/pages/periodic/PeriodicList/index.vue
@@ -32,7 +32,6 @@
                                 :placeholder="i18n.enabledPlaceholder"
                                 :list="enabledList"
                                 :selected.sync="enabledSync"
-                                :searchable="true"
                                 :allow-clear="true"
                                 @clear="onClearSelectedEnabled"
                                 @item-selected="onSelectEnabled">
@@ -192,7 +191,6 @@
                     page: gettext('页'),
                     periodicNamePlaceholder: gettext('请输入任务名称'),
                     creatorPlaceholder: gettext('请输入创建人'),
-                    statusPlaceholder: gettext('请选择状态'),
                     enabled: gettext('状态'),
                     periodicName: gettext('名称'),
                     editTitle: gettext('请暂停任务后再执行编辑操作'),

--- a/frontend/desktop/src/scss/datastatistics/datastatistics.scss
+++ b/frontend/desktop/src/scss/datastatistics/datastatistics.scss
@@ -50,9 +50,13 @@
                         border:none;
                     }
                 }
+                .date-scope {
+                    margin-right: 0px;
+                }
                 .content-date-picker {
                     display: inline-block;
                     cursor: pointer;
+                    margin-right: 80px;
                 }
             }
         }


### PR DESCRIPTION
- 优化项
    - 部分选择器的选择项只有两条，没必要增加搜索效果，所以去除部分选择器的搜索框
    - 优化运营数据里的时间维度选择器顺序，把选择每天或每月的选择器放置在最后
- bug fix
    - 无
link #414 
