### PR TITLE
sprintfix: 前端打包路径加上static、公共路径'/'符号问题修复

### DIFF
--- a/frontend/mobile/build/config.js
+++ b/frontend/mobile/build/config.js
@@ -33,7 +33,7 @@ console.log('build mode:', process.env.NODE_ENV)
 console.log('SITE_URL:', SITE_URL)
 console.log('publicPath:', STATIC_ENV)
 
-const prodPubPath = SITE_URL + '/static/mobile/' + (STATIC_ENV ? STATIC_ENV + '/' : '')
+const prodPubPath = SITE_URL + '/static/weixin/' + (STATIC_ENV ? STATIC_ENV + '/' : '')
 
 export default {
     build: {

--- a/frontend/mobile/build/config.js
+++ b/frontend/mobile/build/config.js
@@ -33,12 +33,14 @@ console.log('build mode:', process.env.NODE_ENV)
 console.log('SITE_URL:', SITE_URL)
 console.log('publicPath:', STATIC_ENV)
 
+const prodPubPath = SITE_URL + '/static/mobile/' + (STATIC_ENV ? STATIC_ENV + '/' : '')
+
 export default {
     build: {
         env: prodEnv,
         assetsRoot: path.resolve(__dirname, '../dist', STATIC_ENV),
         assetsSubDirectory: 'dist',
-        assetsPublicPath: SITE_URL + '/mobile/' + STATIC_ENV,
+        assetsPublicPath: prodPubPath,
         productionSourceMap: true,
         productionGzip: false,
         productionGzipExtensions: ['js', 'css'],


### PR DESCRIPTION
- bug fix
    - 前端打包路径加上 static 和 '/' 符号
    - mobile 改为 weixin
