### PR TITLE
minor:轻应用浮框颜色还原及修复鼠标移入右侧覆盖边框

### DIFF
--- a/frontend/desktop/src/pages/appmaker/AppCard.vue
+++ b/frontend/desktop/src/pages/appmaker/AppCard.vue
@@ -260,6 +260,7 @@
     float: left;
     width: 60%;
     height: 100%;
+    background: #f7f9fa;
     .app-detail {
         padding: 20px;
         font-size: 12px;

--- a/frontend/desktop/src/pages/appmaker/AppCard.vue
+++ b/frontend/desktop/src/pages/appmaker/AppCard.vue
@@ -29,20 +29,24 @@
                 </a>
             </div>
             <div class="card-operation">
-                <span class="common-icon-box-pen operate-btn"
+                <span
+                    class="common-icon-box-pen operate-btn"
                     :title="i18n.modifier"
                     @click.stop="onCardEdit">
                 </span>
-                <span class="common-icon-black-figure operate-btn"
+                <span
+                    class="common-icon-black-figure operate-btn"
                     :title="i18n.jurisdiction"
                     @click.stop="onOpenPermissions">
                 </span>
-                <span class="common-icon-gray-edit operate-btn"
+                <span
+                    class="common-icon-gray-edit operate-btn"
                     @mouseenter="onShowOperation"
                     @mouseleave="onHideOperation">
                 </span>
             </div>
-            <div class="edit-box-background"
+            <div
+                class="edit-box-wrapper"
                 v-if="isShowEdit"
                 @mouseenter="onShowOperation"
                 @mouseleave="onHideOperation">
@@ -155,18 +159,18 @@
         }
     }
 }
-.edit-box-background {
+.edit-box-wrapper {
     position: absolute;
-    left: 111px;
-    top: 142px;
+    left: 30%;
+    top: 140px;
     z-index: 10;
-    padding-left: 6px;
+    padding-left: 12px;
     width: 102px;
     cursor: pointer;
 }
 .card-basic {
     float: left;
-    width: 136px;
+    width: 40%;
     height: 100%;
     padding: 20px 15px;
     overflow: hidden;
@@ -233,29 +237,28 @@
         .edit-operation {
             width: 96px;
             height: 42px;
-            color: #63656e;
+            color: #fff;
             font-size: 12px;
             font-weight: 400;
             line-height: 42px;
             text-align: center;
-            background: #fff;
+            background: #979ba5;
             &:hover {
-                color: #3a84ff;
-                background: #ebf4ff;
+                background: #63656e;
             }
         }
 }
 .edit-box>li>a {
     display: block;
-    color: #63656e;
+    color: #fff;
     height: 42px;
     &:hover {
-        color: #3a84ff;
-        background: rgb#ebf4ff;
+        background: #63656e;
     }
 }
 .card-particular {
     float: left;
+    width: 60%;
     height: 100%;
     .app-detail {
         padding: 20px;
@@ -286,7 +289,7 @@
         position: absolute;
         bottom: 0px;
         height: 100%;
-        width: 70%;
+        width: 60%;
         background: #f7f9fa;
         font-weight: bold;
         font-size: 12px;


### PR DESCRIPTION
- 优化项
    - 轻应用“更多”浮框颜色还原
    - 修复鼠标移入轻应用右侧时详情覆盖了边框
- bug fix
    - 无
link #446 
