### PR TITLE
bugfix:修复周期任务和任务记录里的新建任务弹窗

### DIFF
--- a/frontend/desktop/src/pages/task/TaskList/TaskCreateDialog.vue
+++ b/frontend/desktop/src/pages/task/TaskList/TaskCreateDialog.vue
@@ -244,6 +244,7 @@
                 this.$router.push(url)
             },
             onCancel () {
+                this.selectedId = ''
                 this.$emit('onCreateTaskCancel')
             },
             onSelectTask (template) {


### PR DESCRIPTION
- bug fix
    - 修复周期任务和任务记录里的新建任务弹窗bug。
       即在打开弹窗选择流程后退出窗口，再次进入后之前选择的流程仍然是被选中状态。
link #457 
