### PR TITLE
bugfix: 移动端全局变量为global对象 #466

### DIFF
--- a/frontend/mobile/src/api/index.js
+++ b/frontend/mobile/src/api/index.js
@@ -15,7 +15,7 @@ import { bus } from '../common/bus'
 
 // axios 实例
 const axiosInstance = axios.create({
-    xsrfCookieName: window.APP_CODE + '_csrftoken',
+    xsrfCookieName: global.APP_CODE + '_csrftoken',
     xsrfHeaderName: 'X-CSRFToken',
     withCredentials: true,
     'X-Requested-With': 'XMLHttpRequest'


### PR DESCRIPTION
- bug fix
    - 移动端全局变量为global对象 window.xxx改成global.xxx
