### PR TITLE
improvement: 远程插件同步列表同步时间为空是显示默认标识

### DIFF
--- a/frontend/desktop/src/pages/admin/manage/SourceSync/index.vue
+++ b/frontend/desktop/src/pages/admin/manage/SourceSync/index.vue
@@ -34,8 +34,8 @@
                 <tbody>
                     <tr v-for="item in list" :key="item.id">
                         <td style="padding: 12px 30px;">{{item.id}}</td>
-                        <td>{{item.start_time}}</td>
-                        <td>{{item.finish_time}}</td>
+                        <td>{{item.start_time || '--'}}</td>
+                        <td>{{item.finish_time || '--'}}</td>
                         <td>{{item.creator}}</td>
                         <td>
                             <div class="task-status">


### PR DESCRIPTION
- 优化项
    - 远程插件同步列表同步时间为空是显示默认标识
