### PR TITLE
bugfix:修复tooltips未对齐

### DIFF
--- a/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/TabGlobalVariables.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/TemplateSetting/TabGlobalVariables.vue
@@ -385,7 +385,8 @@
                 color:#f4aa1a;
             }
         }
-        .bk-tooltip-popper {
+        /deep/.bk-tooltip-popper {
+            transform: translate3d(-7px, 104px, 0px) !important;
             .tips-item {
                 margin-bottom: 20px;
                 &:last-child {


### PR DESCRIPTION
- bug fix
    - 新建任务中的新建变量后面的tooltips在鼠标移入时，展示的提示信息箭头偏移
link #547 