### PR TITLE
bugfix:标准插件参数加载中关闭侧边栏，再次打开参数不会刷新

### DIFF
--- a/frontend/desktop/src/components/common/RenderForm/tags/TagSelect.vue
+++ b/frontend/desktop/src/components/common/RenderForm/tags/TagSelect.vue
@@ -143,6 +143,7 @@
         },
         mounted () {
             this.remoteMethod()
+            this.updateForm(this.value)
         },
         methods: {
             filterLabel (val) {


### PR DESCRIPTION
- bug fix
    - 在执行作业插件加载全局变量时关闭侧栏，全局变量无法对应到正确的作业模板
link #562 
