### PR TITLE
sprintFIx: 修复切换缓存图标消失问题

### DIFF
--- a/frontend/desktop/src/pages/template/TemplateEdit/index.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/index.vue
@@ -866,6 +866,7 @@
                     this.$nextTick(() => {
                         this.isClickDraft = type === 'replace'
                         this.$refs.templateSetting.onTemplateSettingShow('localDraftTab')
+                        this.upDataAllNodeInfo()
                     })
                 })
             },
@@ -900,6 +901,21 @@
             },
             updateLocalTemplateData () {
                 this.localTemplateData = this.getLocalTemplateData()
+            },
+            // 重新获得缓存后，更新 dom data[raw]上绑定的数据
+            upDataAllNodeInfo () {
+                const nodes = this.draftArray[0].data.template.activities
+                Object.keys(nodes).forEach((node, index) => {
+                    this.onUpdateNodeInfo(node, {
+                        status: '',
+                        name: nodes[node].name,
+                        stage_name: nodes[node].stage_name,
+                        optional: nodes[node].optional,
+                        error_ignorable: nodes[node].error_ignorable,
+                        can_retry: nodes[node].can_retry,
+                        isSkipped: nodes[node].isSkipped
+                    })
+                })
             }
         },
         beforeRouteLeave (to, from, next) { // leave or reload page


### PR DESCRIPTION
- bug fix
    - 修复切换缓存图标消失问题
    - 原因：从缓存里更新数据后绑定在 dom 上的数据没被更新
