### PR TITLE
bugfix: 修复 JOB 快速执行脚本完成时获取全局变量失败的问题

### DIFF
--- a/pipeline_plugins/components/collections/sites/open/job.py
+++ b/pipeline_plugins/components/collections/sites/open/job.py
@@ -274,6 +274,7 @@ class JobFastExecuteScriptService(JobService):
         job_script = data.get_one_of_inputs('job_script')
 
         biz_cc_id = job_script['biz_cc_id']
+        data.inputs.biz_cc_id = biz_cc_id
         original_ip_list = data.get_one_of_inputs('job_ip_list')
         ip_info = cc_get_ips_info_by_str(
             username=executor,


### PR DESCRIPTION
- bug fix
    - 修复 JOB 快速执行脚本完成时获取全局变量失败的问题
