### PR TITLE
bugfix: 修复未引用全局变量被视为必填，子流程跳转样式修复；优化未选中时错误提示样式优，定位到当前选中的流程

### DIFF
--- a/frontend/desktop/src/pages/task/ParameterInfo.vue
+++ b/frontend/desktop/src/pages/task/ParameterInfo.vue
@@ -34,7 +34,6 @@
             <TaskParamEdit
                 class="unreferenced"
                 v-show="isUnrefVarShow"
-                ref="TaskParamEdit"
                 :show-required="false"
                 :constants="unReferencedVariable"
                 :editable="false"

--- a/frontend/desktop/src/pages/template/TemplateEdit/NodeConfig.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/NodeConfig.vue
@@ -1246,7 +1246,7 @@
     }
 }
 /deep/.icon-edit2:before {
-    content: "\e938";
+    content: '\e908';
     font-family: 'commonicon' !important;
     font-size: 16px;
     color: #546a9e;

--- a/frontend/desktop/src/pages/template/TemplateEdit/index.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/index.vue
@@ -42,7 +42,7 @@
             <NodeConfig
                 ref="nodeConfig"
                 :cc_id="cc_id"
-                v-if="isNodeConfigPanelShow"
+                v-show="isNodeConfigPanelShow"
                 :template_id="template_id"
                 :single-atom="singleAtom"
                 :sub-atom="subAtom"

--- a/frontend/desktop/src/pages/template/TemplateList/ExportTemplateDialog.vue
+++ b/frontend/desktop/src/pages/template/TemplateList/ExportTemplateDialog.vue
@@ -594,7 +594,7 @@
     }
     .task-footer {
         position: absolute;
-        right: 210px;
+        right: 290px;
         bottom: -40px;
         .error-info {
             margin-right: 20px;


### PR DESCRIPTION
- 优化项
    - 关闭子流程节点后重新打开，流程模板选择框希望能定位到当前选中的流程
    - 导出流程/公共流程未选中时错误提示样式优化
- bug fix
    - 修改子流程跳转样式修复
    - 修复未引用全局变量，在新建流程时被视为必填
