### PR TITLE
improve: 周期tab垂直居中，任务执行icon位置调整，强制生效tips调整，周期任务title调整

### DIFF
--- a/frontend/desktop/src/components/common/Individualization/loopRuleSelect.vue
+++ b/frontend/desktop/src/components/common/Individualization/loopRuleSelect.vue
@@ -594,6 +594,7 @@ $bgBlue: #3a84ff;
         /deep/ .tab2-nav-item {
             width: 20%;
             border-bottom: 1px solid $commonBorderColor;
+            line-height: 40px !important;
             &:not(:first-child) {
                 border-left: 1px solid $commonBorderColor !important;
             }

--- a/frontend/desktop/src/pages/config/index.vue
+++ b/frontend/desktop/src/pages/config/index.vue
@@ -38,7 +38,7 @@
                         :is-square="false"
                         @change="onSwitchChange">
                     </bk-switcher>
-                    <bk-tooltip placement="right" width="400" class="desc-tooltip force-tooltip">
+                    <bk-tooltip placement="right" width="280" class="desc-tooltip force-tooltip">
                         <i class="bk-icon icon-info-circle"></i>
                         <div slot="content" style="white-space: normal;">
                             <div>{{i18n.alwaysUseTips}}</div>
@@ -176,11 +176,10 @@
         color: #c4c6cc;
         position: relative;
         top: 3px;
-        left: 5px;
+        left: 6px;
     }
     .force-tooltip {
         position: relative;
-        left: 460px;
     }
     .icon-info-circle:hover {
         color: #f4aa1a

--- a/frontend/desktop/src/pages/periodic/PeriodicList/ModifyPeriodicDialog.vue
+++ b/frontend/desktop/src/pages/periodic/PeriodicList/ModifyPeriodicDialog.vue
@@ -21,7 +21,7 @@
         @cancel="onModifyPeriodicCancel">
         <div slot="content" v-bkloading="{ isLoading: loading, opacity: 1 }">
             <div class="periodic-info">
-                <h3 class="common-section-title">{{ i18n.periodicInfo }}</h3>
+                <h3 class="local-section-title">{{ i18n.periodicInfo }}</h3>
                 <div class="common-form-item">
                     <LoopRuleSelect
                         ref="loopRuleSelect"
@@ -30,7 +30,7 @@
                 <div
                     v-if="!loading"
                     class="param-info">
-                    <h3 class="common-section-title">{{ i18n.paramsInfo }}</h3>
+                    <h3 class="local-section-title">{{ i18n.paramsInfo }}</h3>
                     <div class="common-form-content">
                         <NoData v-if="isVariableEmpty"></NoData>
                         <TaskParamEdit
@@ -224,9 +224,13 @@
 .periodic-info {
     padding-bottom: 40px;
 }
-.common-section-title {
-    margin-bottom: 24px;
-    padding-left: 16px;
+.local-section-title {
+    font-size: 14px;
+    line-height: 32px;
+    font-weight: 600;
+    color: #313238;
+    border-bottom: 1px solid #cacedb;
+    margin-bottom: 30px;
 }
 .periodic-img-tooltip {
     float: right;

--- a/frontend/desktop/src/pages/task/TaskExecute/TaskOperation.vue
+++ b/frontend/desktop/src/pages/task/TaskExecute/TaskOperation.vue
@@ -1320,6 +1320,9 @@
             .solid-eye {
                 font-size: 12px;
             }
+            .params-btn-icon, .params-btn {
+                font-size: 15px;
+            }
         }
     }
 }


### PR DESCRIPTION
- 优化项
    - 周期表达式tab没有纵向居中对齐
    - 任务执行右侧操作icon尺寸偏小
    - 强制生效 tips 宽度减少，icon 左移
    - 编辑周期任务tilte和表单项的样式统一