### PR TITLE
bugfix: 修复mako语法中包含#解析时出现memory error的问题，包含#字符的mako语法不再解析 #713

### DIFF
--- a/pipeline/core/data/expression.py
+++ b/pipeline/core/data/expression.py
@@ -23,7 +23,8 @@ from pipeline import exceptions
 
 
 logger = logging.getLogger('root')
-TEMPLATE_PATTERN = re.compile(r'\${[^${}]+}')
+# find mako template(format is ${xxx}，and ${}# not in xxx, # may raise memory error)
+TEMPLATE_PATTERN = re.compile(r'\${[^${}#]+}')
 
 
 def format_constant_key(key):


### PR DESCRIPTION
- bug fix
    - 修复mako语法中包含#解析时出现memory error的问题，包含#字符的mako语法不再解析 

close #713
