### PR TITLE
bugfix: mock掉test引擎中的logger

### DIFF
--- a/pipeline/component_framework/test.py
+++ b/pipeline/component_framework/test.py
@@ -141,6 +141,7 @@ class ComponentTestMixin(object):
                     bound_service = component.service()
 
                     setattr(bound_service, 'id', case.service_id)
+                    setattr(bound_service, 'logger', MagicMock())
 
                     data = DataObject(inputs=case.inputs)
                     parent_data = DataObject(inputs=case.parent_data)


### PR DESCRIPTION
- bug fix
    - 解决单元测试中Service对象调用logger出错的问题
