### PR TITLE
bugfix: 解决单元测试中Service对象没有logger属性的错误

### DIFF
--- a/pipeline/component_framework/test.py
+++ b/pipeline/component_framework/test.py
@@ -141,6 +141,7 @@ class ComponentTestMixin(object):
                     bound_service = component.service()
 
                     setattr(bound_service, 'id', case.service_id)
+                    setattr(bound_service, 'logger', MagicMock())
 
                     data = DataObject(inputs=case.inputs)
                     parent_data = DataObject(inputs=case.parent_data)


### PR DESCRIPTION
- bug fix
    - mock掉单元测试中的logger
close#895