### PR TITLE
bugfix: tagdatatable单元格校验功能恢复

### DIFF
--- a/frontend/desktop/src/components/common/RenderForm/tags/TagDatatable.vue
+++ b/frontend/desktop/src/components/common/RenderForm/tags/TagDatatable.vue
@@ -224,7 +224,8 @@
                     showGroup: false,
                     showLabel: false,
                     editable: this.editRowNumber === index,
-                    formMode: this.editRowNumber === index
+                    formMode: this.editRowNumber === index,
+                    validateSet: ['required', 'custom', 'regex']
                 }
             },
             onEdit (index, row) {


### PR DESCRIPTION
- bug fix
    - tagdatatable单元格的校验功能恢复
close #927 