### PR TITLE
improve: S3远程插件读取文件超时时间设置为10s,重试次数改为2次 #966

### DIFF
--- a/pipeline/contrib/external_plugins/tests/utils/importer/test_s3.py
+++ b/pipeline/contrib/external_plugins/tests/utils/importer/test_s3.py
@@ -15,7 +15,7 @@ from django.test import TestCase
 
 from pipeline.contrib.external_plugins.tests.mock import *  # noqa
 from pipeline.contrib.external_plugins.tests.mock_settings import *  # noqa
-from pipeline.contrib.external_plugins.utils.importer.s3 import S3ModuleImporter
+from pipeline.contrib.external_plugins.utils.importer.s3 import S3ModuleImporter, CONFIG
 
 GET_FILE_RETURN = 'GET_FILE_RETURN'
 GET_SOURCE_RETURN = 'a=1'
@@ -50,7 +50,8 @@ class S3ModuleImporterTestCase(TestCase):
         self.assertEqual(importer.s3, mock_s3_resource('s3',
                                                        aws_access_key_id=self.access_key,
                                                        aws_secret_access_key=self.secret_key,
-                                                       endpoint_url=self.service_address))
+                                                       endpoint_url=self.service_address,
+                                                       config=CONFIG))
 
         importer = S3ModuleImporter(name='name',
                                     modules=[],
@@ -62,7 +63,8 @@ class S3ModuleImporterTestCase(TestCase):
         self.assertEqual(importer.s3, mock_s3_resource('s3',
                                                        aws_access_key_id=self.access_key,
                                                        aws_secret_access_key=self.secret_key,
-                                                       endpoint_url=self.service_address))
+                                                       endpoint_url=self.service_address,
+                                                       config=CONFIG))
 
         self.assertRaises(ValueError,
                           S3ModuleImporter,
@@ -84,7 +86,8 @@ class S3ModuleImporterTestCase(TestCase):
         self.assertEqual(importer.s3, mock_s3_resource('s3',
                                                        aws_access_key_id=self.access_key,
                                                        aws_secret_access_key=self.secret_key,
-                                                       endpoint_url=self.not_secure_service_address))
+                                                       endpoint_url=self.not_secure_service_address,
+                                                       config=CONFIG))
 
     def test_is_package(self):
         importer = S3ModuleImporter(name='name',

--- a/pipeline/contrib/external_plugins/utils/importer/s3.py
+++ b/pipeline/contrib/external_plugins/utils/importer/s3.py
@@ -15,10 +15,12 @@ import logging
 
 import boto3
 from botocore.exceptions import ClientError
+from botocore.client import Config
 
 from pipeline.contrib.external_plugins.utils.importer.base import AutoInstallRequirementsImporter
 
 logger = logging.getLogger('root')
+CONFIG = Config(connect_timeout=10, read_timeout=10, retries={"max_attempts": 2})
 
 
 class S3ModuleImporter(AutoInstallRequirementsImporter):
@@ -44,7 +46,8 @@ class S3ModuleImporter(AutoInstallRequirementsImporter):
         self.s3 = boto3.resource('s3',
                                  aws_access_key_id=access_key,
                                  aws_secret_access_key=secret_key,
-                                 endpoint_url=self.service_address)
+                                 endpoint_url=self.service_address,
+                                 config=CONFIG)
         self.obj_cache = {}
 
     def is_package(self, fullname):


### PR DESCRIPTION
- 优化项
    - S3远程插件读取文件超时时间设置为10s,重试次数改为2次 

close #966
