### PR TITLE
sprintfix: 修复从 JWT 获取 bk_username 报错 500 的问题 #1106

### DIFF
--- a/gcloud/apigw/decorators.py
+++ b/gcloud/apigw/decorators.py
@@ -39,7 +39,7 @@ def check_white_apps(request):
 
 
 def inject_user(request):
-    username = getattr(request.jwt.app, settings.APIGW_USER_USERNAME_KEY)
+    username = getattr(request.jwt.user, settings.APIGW_USER_USERNAME_KEY)
     user_model = get_user_model()
     try:
         user = user_model.objects.get(username=username)


### PR DESCRIPTION
- bug fix
    - 修复从 JWT 获取 bk_username 报错 500 的问题 

link #1106
