### PR TITLE
bugfix: 修复转移主机模块插件调用 CC 接口时模块 ID 传递错误的问题

### DIFF
--- a/pipeline_plugins/components/collections/sites/open/cc.py
+++ b/pipeline_plugins/components/collections/sites/open/cc.py
@@ -189,7 +189,7 @@ class CCTransferHostModuleService(Service):
             data.set_outputs('ex_data', host_result['message'])
             return False
 
-        cc_module_select = data.get_one_of_inputs('cc_module_select')
+        cc_module_select = cc_format_tree_mode_id(data.get_one_of_inputs('cc_module_select'))
         cc_is_increment = data.get_one_of_inputs('cc_is_increment')
 
         cc_kwargs = {


### PR DESCRIPTION
- bug fix
    - 修复转移主机模块插件调用 CC 接口时模块 ID 传递错误的问题

close #1201
