### PR TITLE
bugfix: 修复 CMDB-故障机替换插件主机不存在时错误信息未国际化问题 #1245

### DIFF
--- a/pipeline_plugins/components/collections/sites/open/cc.py
+++ b/pipeline_plugins/components/collections/sites/open/cc.py
@@ -368,11 +368,11 @@ class CCReplaceFaultMachineService(Service):
             new_host = host_dict.get(new_ip)
 
             if not fault_host:
-                data.outputs.ex_data = _(u"无法查询到 %s 机器信息，请确认该机器是否在当前业务下" % fault_ip)
+                data.outputs.ex_data = _(u"无法查询到 %s 机器信息，请确认该机器是否在当前业务下") % fault_ip
                 return False
 
             if not new_host:
-                data.outputs.ex_data = _(u"无法查询到 %s 机器信息，请确认该机器是否在当前业务下" % new_ip)
+                data.outputs.ex_data = _(u"无法查询到 %s 机器信息，请确认该机器是否在当前业务下") % new_ip
                 return False
 
             update_item = {


### PR DESCRIPTION
- bug fix
    - 修复 CMDB-故障机替换插件主机不存在时错误信息未国际化问题 

close #1245
