### PR TITLE
bugfix: magicbox版本升级select api变更导致页面下拉框无法使用修复

### DIFF
--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "art-template": "^4.13.0",
     "axios": "^0.18.0",
-    "bk-magic-vue": "^2.1.0",
+    "bk-magic-vue": "2.1.4",
     "element-ui": "^2.4.1",
     "jquery": "^3.3.1",
     "jsencrypt": "^3.0.0-rc.1",


### PR DESCRIPTION
- bug fix
    - magicbox版本升级select api变更导致页面下拉框无法使用修复
