### PR TITLE
画布只读模式不可拖拽连线、节点连线端点改为半圆

### DIFF
--- a/frontend/desktop/src/components/common/TemplateCanvas/index.vue
+++ b/frontend/desktop/src/components/common/TemplateCanvas/index.vue
@@ -169,6 +169,14 @@
                 lines,
                 nodes
             }
+            let combinedEndpointOptions = endpointOptions
+            if (!this.editable) {
+                combinedEndpointOptions = Object.assign({}, endpointOptions, {
+                    isTarget: false,
+                    isSource: false,
+                    connectionsDetachable: false
+                })
+            }
             return {
                 idOfNodeShortcutPanel: '',
                 showNodeMenu: false,
@@ -193,7 +201,7 @@
                     arrow: ''
                 },
                 flowData,
-                endpointOptions,
+                endpointOptions: combinedEndpointOptions,
                 connectorOptions
             }
         },

--- a/frontend/desktop/src/components/common/TemplateCanvas/index.vue
+++ b/frontend/desktop/src/components/common/TemplateCanvas/index.vue
@@ -819,7 +819,7 @@
             user-select: none;
         }
         .jtk-endpoint {
-            z-index: 4;
+            z-index: 2;
             cursor: pointer;
         }
         .jsflow-node {

--- a/frontend/desktop/src/components/common/TemplateCanvas/options.js
+++ b/frontend/desktop/src/components/common/TemplateCanvas/options.js
@@ -33,8 +33,8 @@ export const endpointOptions = {
     connectorOverlays: [
         ['PlainArrow', { width: 8, length: 6, location: 1, id: 'arrow' }]
     ],
-    paintStyle: { fill: 'rgba(0, 0, 0, 0)', strokeWidth: 1, radius: 7 },
-    hoverPaintStyle: { fill: '#348af3', stroke: '#348af3' },
+    paintStyle: { fill: 'transparent', stroke: 'transparent', strokeWidth: 6, radius: 8 },
+    hoverPaintStyle: { fill: '#3a84ff', stroke: 'transparent', strokeWidth: 6 },
     cssClass: 'template-canvas-endpoint',
     hoverClass: 'template-canvas-endpoint-hover',
     isSource: true, // 端点是否可以作为拖动源


### PR DESCRIPTION
- 优化项
    - 画布只读模式不可拖拽连线
    - 节点连线端点改为半圆
