### PR TITLE
bugfix: fixed node select panic

### DIFF
--- a/frontend/desktop/src/pages/template/TemplateEdit/NodeConfig.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/NodeConfig.vue
@@ -836,8 +836,8 @@
                 }
                 this.nodeName = nodeName
                 this.nodeConfigData.name = nodeName
-                this.updateActivities()
                 this.getConfig()
+                this.updateActivities()
                 this.$nextTick(() => {
                     this.isAtomChanged = false
                 })


### PR DESCRIPTION
- bug fix
    - 见 #1379 ，新建流程时，如果先添加了一个A类型的插件节点，随后新建一个空节点时，如果选择和上一个相同类型的插件节点会导致panic。
