### PR TITLE
bugfix: 修复部分历史数据 template_source 为 business 导致的任务无法读取及周期任务模板名空白的问题（V3.5.X）

### DIFF
--- a/gcloud/apigw/views.py
+++ b/gcloud/apigw/views.py
@@ -31,7 +31,7 @@ from pipeline_web.drawing_new.drawing import draw_pipeline
 
 from gcloud import err_code
 from gcloud.conf import settings
-from gcloud.constants import PROJECT, BUSINESS, ONETIME
+from gcloud.constants import PROJECT, ONETIME
 from gcloud.apigw.decorators import (
     mark_request_whether_is_trust,
     api_verify_perms,
@@ -49,6 +49,7 @@ from gcloud.commons.template.utils import read_encoded_template_data
 from gcloud.commons.template.permissions import common_template_resource
 from gcloud.tasktmpl3 import varschema
 from gcloud.tasktmpl3.models import TaskTemplate
+from gcloud.tasktmpl3.constants import NON_COMMON_TEMPLATE_TYPES
 from gcloud.contrib.analysis.analyse_items import task_flow_instance
 from gcloud.tasktmpl3.permissions import task_template_resource
 from gcloud.taskflow3.models import TaskFlowInstance
@@ -124,7 +125,7 @@ def format_template_data(template, project=None):
 def get_template_list(request, project_id):
     template_source = request.GET.get('template_source', PROJECT)
     project = request.project
-    if template_source in {BUSINESS, PROJECT}:
+    if template_source in NON_COMMON_TEMPLATE_TYPES:
         templates = TaskTemplate.objects.select_related('pipeline_template').filter(project_id=project.id,
                                                                                     is_deleted=False)
     else:
@@ -144,7 +145,7 @@ def get_template_list(request, project_id):
 def get_template_info(request, template_id, project_id):
     project = request.project
     template_source = request.GET.get('template_source', PROJECT)
-    if template_source in {BUSINESS, PROJECT}:
+    if template_source in NON_COMMON_TEMPLATE_TYPES:
         try:
             tmpl = TaskTemplate.objects.select_related('pipeline_template').get(id=template_id,
                                                                                 project_id=project.id,
@@ -257,7 +258,7 @@ def create_task(request, template_id, project_id):
         params=params))
 
     # 兼容老版本的接口调用
-    if template_source in {BUSINESS, PROJECT}:
+    if template_source in NON_COMMON_TEMPLATE_TYPES:
         template_source = PROJECT
         try:
             tmpl = TaskTemplate.objects.select_related('pipeline_template').get(id=template_id,
@@ -609,7 +610,7 @@ def create_periodic_task(request, template_id, project_id):
                                                                                         project_id=project.id,
                                                                                         params=params))
 
-    if template_source in {BUSINESS, PROJECT}:
+    if template_source in NON_COMMON_TEMPLATE_TYPES:
         template_source = PROJECT
         try:
             template = TaskTemplate.objects.get(pk=template_id, project_id=project.id, is_deleted=False)

--- a/gcloud/periodictask/models.py
+++ b/gcloud/periodictask/models.py
@@ -25,6 +25,7 @@ from pipeline_web.wrapper import PipelineTemplateWebWrapper
 from gcloud.core.models import Project
 from gcloud.periodictask.exceptions import InvalidOperationException
 from gcloud.tasktmpl3.models import TaskTemplate
+from gcloud.tasktmpl3.constants import NON_COMMON_TEMPLATE_TYPES
 from gcloud.taskflow3.models import TaskFlowInstance
 
 logger = logging.getLogger("root")
@@ -135,7 +136,7 @@ class PeriodicTask(models.Model):
     @property
     def task_template_name(self):
         name = ''
-        if self.template_source == PROJECT:
+        if self.template_source in NON_COMMON_TEMPLATE_TYPES:
             try:
                 template = TaskTemplate.objects.get(project=self.project, id=self.template_id)
             except TaskTemplate.DoesNotExist:

--- a/gcloud/taskflow3/models.py
+++ b/gcloud/taskflow3/models.py
@@ -62,6 +62,7 @@ from gcloud.core.utils import (
 )
 from gcloud.commons.template.models import replace_template_id, CommonTemplate
 from gcloud.tasktmpl3.models import TaskTemplate
+from gcloud.tasktmpl3.constants import NON_COMMON_TEMPLATE_TYPES
 from gcloud.taskflow3.constants import (
     TASK_CREATE_METHOD,
     TEMPLATE_SOURCE,
@@ -863,7 +864,7 @@ class TaskFlowInstance(models.Model):
     def template(self):
         if self.template_source == ONETIME:
             return None
-        elif self.template_source == PROJECT:
+        elif self.template_source in NON_COMMON_TEMPLATE_TYPES:
             return TaskTemplate.objects.get(pk=self.template_id)
         else:
             return CommonTemplate.objects.get(pk=self.template_id)

--- a/gcloud/tasktmpl3/constants.py
+++ b/gcloud/tasktmpl3/constants.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""
+Tencent is pleased to support the open source community by making 蓝鲸智云PaaS平台社区版 (BlueKing PaaS Community
+Edition) available.
+Copyright (C) 2017-2019 THL A29 Limited, a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+"""
+
+from gcloud.constants import *  # noqa
+
+# history data compatible, some history data's template_source is still 'business'
+NON_COMMON_TEMPLATE_TYPES = {BUSINESS, PROJECT}


### PR DESCRIPTION
    - 修复部分历史数据 template_source 为 business 导致的任务无法读取及周期任务模板名空白的问题
