### PR TITLE
bugfix: 修复tagTree在查看模式下子节点未选中时会展示父节点的问题(V3.4.X)

### DIFF
--- a/frontend/desktop/src/components/common/RenderForm/tags/TagTree.vue
+++ b/frontend/desktop/src/components/common/RenderForm/tags/TagTree.vue
@@ -165,7 +165,9 @@
                         return item
                     } else if (item.children) {
                         item.children = this.filterTreeItem(item.children)
-                        return item
+                        if (item.children.length > 0) {
+                            return item
+                        }
                     }
                 })
             }


### PR DESCRIPTION
- bug fix
    - 修复tagTree在查看模式下子节点未选中时会展示父节点的问题
