### PR TITLE
bugfix: 添加收藏 searchInput 下拉不显示, magicbox 升级到 2.1.9-beta.5

### DIFF
--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -14,7 +14,7 @@
     "ajv": "^6.10.2",
     "art-template": "^4.13.0",
     "axios": "^0.18.0",
-    "bk-magic-vue": "2.1.8",
+    "@tencent/bk-magic-vue": "2.1.9-beta.15",
     "element-ui": "^2.4.1",
     "file-saver": "^2.0.2",
     "jquery": "^3.3.1",

--- a/frontend/desktop/package.json
+++ b/frontend/desktop/package.json
@@ -14,7 +14,7 @@
     "ajv": "^6.10.2",
     "art-template": "^4.13.0",
     "axios": "^0.18.0",
-    "@tencent/bk-magic-vue": "2.1.9-beta.15",
+    "bk-magic-vue": "2.1.9-beta.5",
     "element-ui": "^2.4.1",
     "file-saver": "^2.0.2",
     "jquery": "^3.3.1",

--- a/frontend/desktop/src/main.js
+++ b/frontend/desktop/src/main.js
@@ -17,8 +17,8 @@ import './directives/index.js'
 import './config/login.js'
 import App from './App.vue'
 import './api/index.js'
-import bkMagicVue, { locale, lang } from '@tencent/bk-magic-vue'
-import '@tencent/bk-magic-vue/dist/bk-magic-vue.min.css'
+import bkMagicVue, { locale, lang } from 'bk-magic-vue'
+import 'bk-magic-vue/dist/bk-magic-vue.min.css'
 import { Input, InputNumber, Select, Radio, RadioGroup, RadioButton, Checkbox,
     CheckboxGroup, Button, Option, OptionGroup, Table, TableColumn,
     DatePicker, TimePicker, TimeSelect, Upload, Tree, Loading,

--- a/frontend/desktop/src/main.js
+++ b/frontend/desktop/src/main.js
@@ -17,8 +17,8 @@ import './directives/index.js'
 import './config/login.js'
 import App from './App.vue'
 import './api/index.js'
-import bkMagicVue, { locale, lang } from 'bk-magic-vue'
-import 'bk-magic-vue/dist/bk-magic-vue.min.css'
+import bkMagicVue, { locale, lang } from '@tencent/bk-magic-vue'
+import '@tencent/bk-magic-vue/dist/bk-magic-vue.min.css'
 import { Input, InputNumber, Select, Radio, RadioGroup, RadioButton, Checkbox,
     CheckboxGroup, Button, Option, OptionGroup, Table, TableColumn,
     DatePicker, TimePicker, TimeSelect, Upload, Tree, Loading,

--- a/frontend/desktop/src/pages/home/AddCollectionDialog.vue
+++ b/frontend/desktop/src/pages/home/AddCollectionDialog.vue
@@ -25,8 +25,10 @@
                 <div class="search-wrapper">
                     <bk-search-select
                         ref="bkSearchSelect"
+                        :popover-zindex="2002"
                         :show-condition="false"
                         :data="searchOptionalList"
+                        :show-popover-tag-change="searchOptionalList.length !== 0"
                         v-model="searchValue"
                         @change="onSearchChange">
                     </bk-search-select>


### PR DESCRIPTION
- 优化项
    - magicbox 升级到 2.1.9-beta.5
- bug fix
    - 添加收藏 searchInput 下拉不显示