### PR TITLE
bugfix: 职能化高级搜索所属项目字段修复

### DIFF
--- a/frontend/desktop/src/pages/functor/FunctionList.vue
+++ b/frontend/desktop/src/pages/functor/FunctionList.vue
@@ -401,7 +401,7 @@
                         offset: (this.pagination.current - 1) * this.pagination.limit,
                         task__pipeline_instance__name__contains: flowName || undefined,
                         creator: creator || undefined,
-                        project__id: selectedProject || undefined,
+                        task__project__id: selectedProject || undefined,
                         status: statusSync || undefined
                     }
                     if (executeTime[0] && executeTime[1]) {


### PR DESCRIPTION
- bug fix
    - 职能化高级搜索所属项目字段project__id 改成 task__project__id