### PR TITLE
bugfix: 职能化高级搜索所属项目字段修复（V3.4.X）

### DIFF
--- a/frontend/desktop/src/pages/functor/index.vue
+++ b/frontend/desktop/src/pages/functor/index.vue
@@ -419,7 +419,7 @@
                         offset: (this.pagination.current - 1) * this.pagination.limit,
                         task__pipeline_instance__name__contains: this.searchStr || undefined,
                         creator: this.creator,
-                        project__id: this.projectId,
+                        task__project__id: this.projectId,
                         status: this.status
                     }
                     if (this.executeEndTime) {


### PR DESCRIPTION
- bug fix
    - 职能化高级搜索project__id 改成 task__project__id