### PR TITLE
bugfix: 修复 open_paas 版本低于 2.10.7 时申请权限跳转链接错误问题 (V3.5.X)

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -279,11 +279,17 @@ BK_IAM_QUERY_INTERFACE = ''
 BK_IAM_RELATED_SCOPE_TYPES = 'system'
 BK_IAM_SYSTEM_MANAGERS = 'admin'
 BK_IAM_SYSTEM_CREATOR = 'admin'
-# 兼容老版本的 open_paas，此时只能从 BK_IAM_HOST 中获取权限中心 api host
-BK_IAM_INNER_HOST = os.getenv('BK_IAM_INNER_HOST', os.getenv('BK_IAM_HOST', ''))
 AUTH_BACKEND_CLS = os.getenv('BKAPP_AUTH_BACKEND_CLS', 'auth_backend.backends.bkiam.BKIAMBackend')
 BK_IAM_APP_CODE = os.getenv('BKAPP_BK_IAM_SYSTEM_ID', 'bk_iam_app')
-BK_IAM_HOST = os.environ.get('BK_IAM_HOST', '{}/o/{}'.format(BK_PAAS_HOST, BK_IAM_APP_CODE))
+
+# 新版本 open_paas，BK_IAM_INNER_HOST -> 权限中心后台 host，BK_IAM_HOST -> 权限中心SaaS host
+if 'BK_IAM_INNER_HOST' in os.environ:
+    BK_IAM_INNER_HOST = os.getenv('BK_IAM_INNER_HOST')
+    BK_IAM_HOST = os.environ.get('BK_IAM_HOST', '{}/o/{}'.format(BK_PAAS_HOST, BK_IAM_APP_CODE))
+# 兼容老版本的 open_paas，此时只能从环境变量中获取权限中心后台 host: BK_IAM_HOST
+else:
+    BK_IAM_INNER_HOST = os.getenv('BK_IAM_HOST', '')
+    BK_IAM_HOST = '{}/o/{}'.format(BK_PAAS_HOST, BK_IAM_APP_CODE)
 
 # 用户管理配置
 BK_USER_MANAGE_HOST = '{}/o/{}'.format(BK_PAAS_HOST, 'bk_user_manage')


### PR DESCRIPTION
- bug fix
    - 修复 open_paas 版本低于 2.10.7 时申请权限跳转链接错误问题 

close #1934
