### PR TITLE
bugfix: 修复变量引擎中 mako 语法错误时渲染参数异常的问题，优化后直接返回原字符串 #2009

### DIFF
--- a/pipeline/core/data/expression.py
+++ b/pipeline/core/data/expression.py
@@ -134,7 +134,7 @@ class ConstantTemplate(object):
             raise exceptions.ConstantTypeException('constant resolve error, template[%s] is not a string' % template)
         try:
             tm = Template(template)
-        except MakoException as e:
+        except (MakoException, SyntaxError) as e:
             logger.error('pipeline resolve template[%s] error[%s]' % (template, e))
             return template
         try:

--- a/pipeline/tests/core/data/test_expression.py
+++ b/pipeline/tests/core/data/test_expression.py
@@ -78,8 +78,11 @@ class TestConstantTemplate(TestCase):
         not_exists = '{a}'
         self.assertEqual(cons_tmpl.resolve_template(not_exists, {}), not_exists)
 
-        syntax_error = '${a.b}'
-        self.assertEqual(cons_tmpl.resolve_template(syntax_error, {}), syntax_error)
+        resolve_syntax_error = '${a.b}'
+        self.assertEqual(cons_tmpl.resolve_template(resolve_syntax_error, {}), resolve_syntax_error)
+
+        template_syntax_error = '${a:b}'
+        self.assertEqual(cons_tmpl.resolve_template(template_syntax_error, {}), template_syntax_error)
 
     def test_resolve(self):
         list_template = expression.ConstantTemplate(['${a}', ['${a}', '${a+int(b)}']])


### PR DESCRIPTION
- bug fix
    - 修复变量引擎中 mako 语法错误时渲染参数异常的问题，优化后直接返回原字符串 

close #2009
