### PR TITLE
imporve: 计算插件耗时方法改为四舍五，而不是向下取整 #2073

### DIFF
--- a/pipeline/engine/utils.py
+++ b/pipeline/engine/utils.py
@@ -51,7 +51,7 @@ def calculate_elapsed_time(started_time, archived_time):
         elapsed_time = (timezone.now() - started_time).total_seconds()
     else:
         elapsed_time = 0
-    return int(elapsed_time)
+    return round(elapsed_time)
 
 
 class ActionResult(object):


### PR DESCRIPTION
- 优化项
    - 计算插件耗时方法改为四舍五，而不是向下取整 

close #2073
