### PR TITLE
bugfix: 修复升级标准运维版本到V3.5.10，导致处于暂停或定时中包含CMDB插件的流程任务无法继续的问题 #2080

### DIFF
--- a/pipeline_plugins/components/collections/sites/open/cc/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/__init__.py
@@ -16,15 +16,15 @@ from django.utils.translation import ugettext_lazy as _
 __group_name__ = _("配置平台(CMDB)")
 
 
-from .batch_delete_set import CCBatchDeleteSetComponent  # noqa
-from .create_set import CCCreateSetComponent  # noqa
-from .empty_set_hosts import CCEmptySetHostsComponent  # noqa
-from .replace_fault_machine import CCReplaceFaultMachineComponent  # noqa
-from .transfer_fault_host import CmdbTransferFaultHostComponent  # noqa
-from .transfer_host_module import CCTransferHostModuleComponent  # noqa
-from .transfer_host_resource import CmdbTransferHostResourceModuleComponent  # noqa
-from .transfer_to_idle import CCTransferHostToIdleComponent  # noqa
-from .update_host import CCUpdateHostComponent  # noqa
-from .update_module import CCUpdateModuleComponent  # noqa
-from .update_set import CCUpdateSetComponent  # noqa
-from .update_set_service_status import CCUpdateSetServiceStatusComponent  # noqa
+from .batch_delete_set import *  # noqa
+from .create_set import *  # noqa
+from .empty_set_hosts import *  # noqa
+from .replace_fault_machine import *  # noqa
+from .transfer_fault_host import *  # noqa
+from .transfer_host_module import *  # noqa
+from .transfer_host_resource import *  # noqa
+from .transfer_to_idle import *  # noqa
+from .update_host import *  # noqa
+from .update_module import *  # noqa
+from .update_set import *  # noqa
+from .update_set_service_status import *  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/batch_delete_set/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/batch_delete_set/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCBatchDeleteSetComponent  # noqa
+from .legacy import CCBatchDeleteSetComponent, CCBatchDeleteSetService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/create_set/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/create_set/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCCreateSetComponent  # noqa
+from .legacy import CCCreateSetComponent, CCCreateSetService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/empty_set_hosts/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/empty_set_hosts/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCEmptySetHostsComponent  # noqa
+from .legacy import CCEmptySetHostsComponent, CCEmptySetHostsService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/replace_fault_machine/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/replace_fault_machine/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCReplaceFaultMachineComponent  # noqa
+from .legacy import CCReplaceFaultMachineComponent, CCReplaceFaultMachineService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/transfer_fault_host/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/transfer_fault_host/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CmdbTransferFaultHostComponent  # noqa
+from .legacy import CmdbTransferFaultHostComponent, CmdbTransferFaultHostService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/transfer_host_module/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/transfer_host_module/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCTransferHostModuleComponent  # noqa
+from .legacy import CCTransferHostModuleComponent, CCTransferHostModuleService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/transfer_host_resource/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/transfer_host_resource/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CmdbTransferHostResourceModuleComponent  # noqa
+from .legacy import CmdbTransferHostResourceModuleComponent, CmdbTransferHostResourceModuleService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/transfer_to_idle/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/transfer_to_idle/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCTransferHostToIdleComponent  # noqa
+from .legacy import CCTransferHostToIdleComponent, CCTransferHostToIdleService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/update_host/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/update_host/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCUpdateHostComponent  # noqa
+from .legacy import CCUpdateHostComponent, CCUpdateHostService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/update_module/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/update_module/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCUpdateModuleComponent  # noqa
+from .legacy import CCUpdateModuleComponent, CCUpdateModuleService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/update_set/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/update_set/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCUpdateSetComponent  # noqa
+from .legacy import CCUpdateSetComponent, CCUpdateSetService  # noqa

--- a/pipeline_plugins/components/collections/sites/open/cc/update_set_service_status/__init__.py
+++ b/pipeline_plugins/components/collections/sites/open/cc/update_set_service_status/__init__.py
@@ -11,4 +11,4 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
-from .legacy import CCUpdateSetServiceStatusComponent  # noqa
+from .legacy import CCUpdateSetServiceStatusComponent, CCUpdateSetServiceStatusService  # noqa


### PR DESCRIPTION
- bug fix
    - 修复升级标准运维版本到V3.5.10，导致处于暂停或定时中包含CMDB插件的流程任务无法继续的问题 

close #2080
