### PR TITLE
bugfix: 修复节点失败重试/修改定时节点的定时时间后，节点执行结束时间未清空的问题 #2129

### DIFF
--- a/pipeline/engine/models/core.py
+++ b/pipeline/engine/models/core.py
@@ -804,6 +804,8 @@ class StatusManager(models.Manager):
         history = History.objects.record(s)
         LogEntry.objects.link_history(node_id=node.id, history_id=history.id)
         s.retry += 1
+        s.started_time = None
+        s.archived_time = None
         s.save()
 
         # update inputs


### PR DESCRIPTION
- bug fix
    - 修复节点失败重试/修改定时节点的定时时间后，节点执行结束时间未清空的问题 

close #2129
