### PR TITLE
optimization: 增加 python 解释器允许的最大递归数上限

### DIFF
--- a/pipeline/apps.py
+++ b/pipeline/apps.py
@@ -89,4 +89,4 @@ class PipelineConfig(AppConfig):
             logger.error("can not find REDIS in settings!")
 
         # avoid big flow pickle raise maximum recursion depth exceeded error
-        sys.setrecursionlimit(50000)
+        sys.setrecursionlimit(10000)

--- a/pipeline/apps.py
+++ b/pipeline/apps.py
@@ -11,6 +11,7 @@ an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express o
 specific language governing permissions and limitations under the License.
 """
 
+import sys
 import logging
 import traceback
 
@@ -86,3 +87,6 @@ class PipelineConfig(AppConfig):
             == "pipeline.engine.core.data.redis_backend.RedisDataBackend"
         ):
             logger.error("can not find REDIS in settings!")
+
+        # avoid big flow pickle raise maximum recursion depth exceeded error
+        sys.setrecursionlimit(50000)


### PR DESCRIPTION
- 优化项
    - 增加 python 解释器允许的最大递归数上限
