### PR TITLE
bugfix:编辑公共流程引用子流程时需要判断common_flow_view权限

### DIFF
--- a/dev_log/dev/fannluo_202007201735.yaml
+++ b/dev_log/dev/fannluo_202007201735.yaml
@@ -1,0 +1,2 @@
+bugfix:
+    - "编辑公共流程引用子流程时需要判断common_flow_view权限"

--- a/frontend/desktop/src/pages/template/TemplateEdit/index.vue
+++ b/frontend/desktop/src/pages/template/TemplateEdit/index.vue
@@ -625,6 +625,7 @@
             // 子流程分组
             handleSubflowGroup (data) {
                 const tplList = data.objects
+                const reqPermssion = this.common ? ['common_flow_view'] : ['flow_view']
                 const groups = this.projectBaseInfo.task_categories.map(item => {
                     return {
                         type: item.value,
@@ -637,7 +638,7 @@
                     if (item.id !== Number(this.template_id)) {
                         const group = groups.find(tpl => tpl.type === item.category)
                         if (group) {
-                            item.hasPermission = this.hasPermission(['flow_view'], item.auth_actions)
+                            item.hasPermission = this.hasPermission(reqPermssion, item.auth_actions)
                             group.list.push(item)
                         }
                     }


### PR DESCRIPTION
- bug fix
    - 编辑公共流程引用子流程时需要判断common_flow_view权限
