### PR TITLE
bugfix: 修复 BKAPP_API_JWT_EXEMPT 环境变量存在时 API 从 HTTP 头部中获取不到 APP CODE 的问题（V3.5.X）

### DIFF
--- a/dev_log/dev/homholueng_202008201556.yaml
+++ b/dev_log/dev/homholueng_202008201556.yaml
@@ -1,0 +1,2 @@
+bugfix:
+    - "修复 BKAPP_API_JWT_EXEMPT 环境变量存在时 API 从 HTTP 头部中获取不到 APP CODE 的问题"

--- a/packages/bkoauth/decorators.py
+++ b/packages/bkoauth/decorators.py
@@ -22,22 +22,21 @@ from .jwt_client import JWTClient, jwt_invalid_view
 def apigw_required(view_func):
     """apigw装饰器
     """
+
     @wraps(view_func, assigned=available_attrs(view_func))
     def _wrapped_view(request, *args, **kwargs):
 
         request.jwt = JWTClient(request)
-        if 'BKAPP_API_JWT_EXEMPT' in os.environ:
+        if "BKAPP_API_JWT_EXEMPT" in os.environ:
             from packages.bkoauth.utils import FancyDict
-            request.jwt.user = FancyDict({
-                'bk_username': request.META.get('HTTP_BK_USERNAME')
-            })
-            request.jwt.app = FancyDict({
-                'bk_app_code': request.META.get('HTTP_BK_APPCODE')
-            })
+
+            request.jwt.user = FancyDict({"bk_username": request.META.get("HTTP_BK_USERNAME")})
+            request.jwt.app = FancyDict({"bk_app_code": request.META.get("HTTP_BK_APP_CODE")})
 
         else:
             if not request.jwt.is_valid:
                 return jwt_invalid_view(request)
 
         return view_func(request, *args, **kwargs)
+
     return _wrapped_view

--- a/packages/bkoauth/decorators.py
+++ b/packages/bkoauth/decorators.py
@@ -17,6 +17,7 @@ from functools import wraps
 from django.utils.decorators import available_attrs
 
 from .jwt_client import JWTClient, jwt_invalid_view
+from .utils import FancyDict
 
 
 def apigw_required(view_func):
@@ -28,8 +29,6 @@ def apigw_required(view_func):
 
         request.jwt = JWTClient(request)
         if "BKAPP_API_JWT_EXEMPT" in os.environ:
-            from packages.bkoauth.utils import FancyDict
-
             request.jwt.user = FancyDict({"bk_username": request.META.get("HTTP_BK_USERNAME")})
             request.jwt.app = FancyDict({"bk_app_code": request.META.get("HTTP_BK_APP_CODE")})
 


### PR DESCRIPTION
- bug fix
    - 修复 BKAPP_API_JWT_EXEMPT 环境变量存在时 API 从 HTTP 头部中获取不到 APP CODE 的问题
