### PR TITLE
minor: add python-magic-bin for pip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ rsa==3.4.2
 django-nose==1.4.5
 coverage==4.5.1
 python-magic==0.4.15
+python-magic-bin==0.4.14
 cryptography==2.3.1
 gitdb2==2.0.6
 GitPython==2.1.11


### PR DESCRIPTION
- 优化项
    - 添加 python-magic-bin 的pip安装，可简化掉去手动安装系统 magic lib 的动作
@howellliang 
