### PR TITLE
minor:修复集群模块IP选择器不选择过滤set或module时，全选集群下ip,单元测试更新

### DIFF
--- a/pipeline_plugins/tests/variables/collections/sites/open/cc/test_var_cmdb_set_module_ip_selector.py
+++ b/pipeline_plugins/tests/variables/collections/sites/open/cc/test_var_cmdb_set_module_ip_selector.py
@@ -695,6 +695,14 @@ IP_SELECTOR_SELECT_METHOD_BIZ_INPUT_INNER_SET_SUCCESS_VALUE = {
     "var_filter_set": "空闲机池,集群2",
     "var_filter_module": "ls",
 }
+IP_SELECTOR_SELECT_METHOD_BIZ_INPUT_NO_FILTER_SET_MODULE_SUCCESS_VALUE = {
+    "var_ip_method": "select",
+    "var_ip_custom_value": "",
+    "var_ip_select_value": {"var_set": ["空闲机池", "集群1"], "var_module": ["空闲机"], "var_module_name": "ip,空闲机"},
+    "var_ip_manual_value": {"var_manual_set": "", "var_manual_module": "", "var_module_name": ""},
+    "var_filter_set": "",
+    "var_filter_module": "",
+}
 IP_SELECTOR_SELECT_METHOD_BIZ_INPUT_INNER_MODULE_SUCCESS_VALUE = {
     "var_ip_method": "select",
     "var_ip_custom_value": "",
@@ -747,6 +755,7 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
         self.custom_method_biz_input_inner_set_success_case_return = "192.168.15.18,192.168.15.4"
         self.select_method_biz_input_inner_module_success_case_return = "192.168.15.18,192.168.15.4"
         self.select_method_biz_input_inner_set_success_case_return = "192.168.15.18,192.168.15.4"
+        self.select_method_no_filter_set_module_success_case_return = "192.168.15.18,192.168.15.4"
 
     def tearDown(self):
         self.cc_get_ips_info_by_str_patcher.stop()
@@ -854,3 +863,13 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             context={},
         )
         self.assertEqual(self.select_method_biz_input_inner_set_success_case_return, set_module_ip_selector.get_value())
+
+    @patch(GET_CLIENT_BY_USER, return_value=SELECT_METHOD_BIZ_INNERIP_SUC_CLIENT)
+    def test_select_method_no_filter_set_module_success_case(self, mock_get_client_by_user_return):
+        set_module_ip_selector = SetModuleIpSelector(
+            pipeline_data=self.pipeline_data,
+            value=IP_SELECTOR_SELECT_METHOD_BIZ_INPUT_NO_FILTER_SET_MODULE_SUCCESS_VALUE,
+            name="test_select_method_no_filter_set_module_success_case",
+            context={},
+        )
+        self.assertEqual(self.select_method_no_filter_set_module_success_case_return, set_module_ip_selector.get_value())

--- a/pipeline_plugins/tests/variables/collections/sites/open/cc/test_var_cmdb_set_module_ip_selector.py
+++ b/pipeline_plugins/tests/variables/collections/sites/open/cc/test_var_cmdb_set_module_ip_selector.py
@@ -955,11 +955,10 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             },
             {
                 "func": CUSTOM_METHOD_SUC_CLIENT.cc.list_biz_hosts,
-                "calls": [
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
+                "calls": [call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
+                          call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
             }
         ])
 
@@ -1003,11 +1002,16 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             },
             {
                 "func": CUSTOM_METHOD_BIZ_INNERIP_SUC_CLIENT.cc.list_biz_hosts,
-                "calls": [
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
+                "calls": [call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
+                          call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'limit': 500, 'start': 0}),
+                          call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5, 3, 4, 5],
+                               bk_supplier_account='supplier_account_token', fields=['bk_host_innerip'],
+                               page={'start': 0, 'limit': 1}),
+                          call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5, 3, 4, 5],
+                               bk_supplier_account='supplier_account_token', fields=['bk_host_innerip'],
+                               page={'limit': 500, 'start': 0})]
             }
         ])
 
@@ -1030,11 +1034,10 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             },
             {
                 "func": CUSTOM_METHOD_BIZ_INNERIP_SUC_CLIENT.cc.list_biz_hosts,
-                "calls": [
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3, 4, 5], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
+                "calls": [call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
+                          call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
             }
         ])
 
@@ -1058,9 +1061,9 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             },
             {
                 "func": SELECT_METHOD_BIZ_INNERIP_SUC_CLIENT.cc.list_biz_hosts,
-                "calls": [call(bk_biz_id=1, bk_module_ids=[60, 61, 3], bk_supplier_account='supplier_account_token',
+                "calls": [call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
                                fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
-                          call(bk_biz_id=1, bk_module_ids=[60, 61, 3], bk_supplier_account='supplier_account_token',
+                          call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
                                fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
             }
         ])
@@ -1119,14 +1122,10 @@ class VarCmdbSetModuleIpSelectorTestCase(TestCase):
             },
             {
                 "func": SELECT_METHOD_BIZ_INNERIP_NO_FILTER_SET_MODULE_SUC_CLIENT.cc.list_biz_hosts,
-                "calls": [
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'],
-                         page={'start': 0, 'limit': 1}),
-                    call(bk_biz_id=1, bk_module_ids=[60, 61, 3], bk_supplier_account='supplier_account_token',
-                         fields=['bk_host_innerip'],
-                         page={'limit': 500, 'start': 0})
-                ]
+                "calls": [call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'start': 0, 'limit': 1}),
+                          call(bk_biz_id=1, bk_module_ids=[60, 61], bk_supplier_account='supplier_account_token',
+                               fields=['bk_host_innerip'], page={'limit': 500, 'start': 0})]
             }
         ])
 

--- a/pipeline_plugins/variables/collections/sites/open/cmdb/var_cmdb_set_module_ip_selector.py
+++ b/pipeline_plugins/variables/collections/sites/open/cmdb/var_cmdb_set_module_ip_selector.py
@@ -159,6 +159,7 @@ def get_module_id_list(
     # 筛选规则与空闲机、待回收、故障机模块取交集
     biz_internal_module = set(BIZ_INTERNAL_MODULE) & set(filter_service_template_names)
 
+    inner_module_id_list = []
     if BIZ_INTERNAL_SET in filter_set_names:
         # 取空闲机池下所有模块ID
         inner_module_id_list = [

--- a/pipeline_plugins/variables/collections/sites/open/cmdb/var_cmdb_set_module_ip_selector.py
+++ b/pipeline_plugins/variables/collections/sites/open/cmdb/var_cmdb_set_module_ip_selector.py
@@ -159,12 +159,13 @@ def get_module_id_list(
     # 筛选规则与空闲机、待回收、故障机模块取交集
     biz_internal_module = set(BIZ_INTERNAL_MODULE) & set(filter_service_template_names)
 
-    # 取空闲机池下所有模块ID
-    inner_module_id_list = [
-        {"default": 0, "bk_module_id": biz_internal_module_item["id"]}
-        for biz_internal_module_item in service_template_list
-        if biz_internal_module_item["name"] in BIZ_INTERNAL_MODULE
-    ]
+    if BIZ_INTERNAL_SET in filter_set_names:
+        # 取空闲机池下所有模块ID
+        inner_module_id_list = [
+            {"default": 0, "bk_module_id": biz_internal_module_item["id"]}
+            for biz_internal_module_item in service_template_list
+            if biz_internal_module_item["name"] in BIZ_INTERNAL_MODULE
+        ]
 
     # 用户输入空闲机，只取空闲机模块ID
     if biz_internal_module:


### PR DESCRIPTION
- bug fix
    - minor:修复集群模块IP选择器不选择过滤set或module时，全选集群下ip,单元测试更新
