### PR TITLE
improve: 插件表格分页每页最大数量配置为 10

### DIFF
--- a/frontend/desktop/src/components/common/RenderForm/tags/TagDatatable.vue
+++ b/frontend/desktop/src/components/common/RenderForm/tags/TagDatatable.vue
@@ -220,7 +220,7 @@
         page_size: {
             type: Number,
             required: false,
-            default: 3,
+            default: 10,
             desc: 'number of items displayed per page'
         },
         row_click_handler: {


### PR DESCRIPTION

- 优化项
    - 插件表格分页每页最大数量配置为 10
