### PR TITLE
bug fix：快速分发文件2.0插件不可用

### DIFF
--- a/pipeline_plugins/components/collections/sites/open/job/fast_push_file/v2_0.py
+++ b/pipeline_plugins/components/collections/sites/open/job/fast_push_file/v2_0.py
@@ -181,7 +181,7 @@ class JobFastPushFileService(JobScheduleService):
 
                 job_kwargs = {
                     "bk_biz_id": biz_cc_id,
-                    "file_source": source,
+                    "file_source": [source],
                     "ip_list": ip_list,
                     "account": job_account,
                     "file_target_path": job_target_path,


### PR DESCRIPTION
- bug fix
    - 快速分发文件2.0插件不可用
