### PR TITLE
bugfix: 修复 supervisor 中 bk_sops_celery 进程启动命令不正确的问题

### DIFF
--- a/support-files/supervisord.conf
+++ b/support-files/supervisord.conf
@@ -21,7 +21,7 @@ autorestart = true
 environment = {{.environment}}
 
 [program: {{.app_code}}_celery]
-command = /cache/.bk/env/bin/python {{.app_container_path}}code/manage.py celery worker -n {{.node_name}}_{{.app_code}} -Q default, task_prepare_api -c 8 -l INFO --maxtasksperchild=50
+command = /cache/.bk/env/bin/python {{.app_container_path}}code/manage.py celery worker -n {{.node_name}}_{{.app_code}} -Q default,task_prepare_api -c 8 -l INFO --maxtasksperchild=50
 directory = {{.app_container_path}}code/
 stdout_logfile = {{.app_container_path}}logs/{{.app_code}}/celery.log
 redirect_stderr = true


### PR DESCRIPTION
bugfix: 修复 supervisor 中 bk_sops_celery 进程启动命令不正确的问题