### PR TITLE
bugfix: 修复 transfer_host_to_recyclemodule API 不存在的问题

### DIFF
--- a/packages/blueking/component/apis/cc.py
+++ b/packages/blueking/component/apis/cc.py
@@ -723,3 +723,9 @@ class CollectionsCC(object):
             path="/api/c/compapi{bk_api_ver}/cc/search_host_lock/",
             description="根据主机id列表查询主机锁",
         )
+        self.transfer_host_to_recyclemodule = ComponentAPI(
+            client=self.client,
+            method="POST",
+            path="/api/c/compapi{bk_api_ver}/cc/transfer_host_to_recyclemodule/",
+            description="上交主机到业务的待回收模块",
+        )


### PR DESCRIPTION
bugfix: 修复 transfer_host_to_recyclemodule API 不存在的问题