### PR TITLE
bugfix: 公共流程删除报错后弹窗不能再次显示修复

### DIFF
--- a/frontend/desktop/src/pages/template/common/CommonTemplateList.vue
+++ b/frontend/desktop/src/pages/template/common/CommonTemplateList.vue
@@ -701,7 +701,6 @@
                     }
                     await this.deleteTemplate(data)
                     this.theDeleteTemplateId = undefined
-                    this.isDeleteDialogShow = false
                     // 最后一页最后一条删除后，往前翻一页
                     if (
                         this.pagination.current > 1
@@ -714,6 +713,7 @@
                 } catch (e) {
                     console.log(e)
                 } finally {
+                    this.isDeleteDialogShow = false
                     this.pending.delete = false
                 }
             },


### PR DESCRIPTION
- bug fix
    - 公共流程删除报错后弹窗不能再次显示修复
