### PR TITLE
improvement : 【优化】作业平台(JOB)-分发本地文件 2.0 版本添加文件后不要清空目标路径

### DIFF
--- a/pipeline_plugins/components/static/components/atoms/job/job_push_local_files/v2_0.js
+++ b/pipeline_plugins/components/static/components/atoms/job/job_push_local_files/v2_0.js
@@ -153,8 +153,6 @@
 
                                     //reset info tag
                                     local_files_obj._set_value([])
-                                    job_target_path_obj._set_value("")
-
                                 }
                             },
                         ]

--- a/static/components/atoms/job/job_push_local_files/v2_0.js
+++ b/static/components/atoms/job/job_push_local_files/v2_0.js
@@ -153,7 +153,6 @@
 
                                     //reset info tag
                                     local_files_obj._set_value([])
-                                    job_target_path_obj._set_value("")
 
                                 }
                             },


### PR DESCRIPTION
- 优化项
    - 作业平台(JOB)-分发本地文件 2.0 版本添加文件后不要清空目标路径
