### PR TITLE
bugfix: 修复创建项目环境变量使用项目查看而不是项目编辑权限的问题

### DIFF
--- a/gcloud/project_constants/apis/drf/permissions.py
+++ b/gcloud/project_constants/apis/drf/permissions.py
@@ -45,7 +45,7 @@ class ProjectConstantPermissions(permissions.BasePermission):
                 iam=iam,
                 system=IAMMeta.SYSTEM_ID,
                 subject=Subject("user", request.user.username),
-                action=Action(IAMMeta.PROJECT_VIEW_ACTION),
+                action=Action(IAMMeta.PROJECT_EDIT_ACTION),
                 resources=project_resources,
             )
 


### PR DESCRIPTION
bugfix: 修复创建项目环境变量使用项目查看而不是项目编辑权限的问题