### PR TITLE
bugfix: 修复 operate_node API 不修改参数重试 engine v2 失败节点时节点数据会被清空的问题

### DIFF
--- a/dev_log/dev/homholueng_202109231453.yaml
+++ b/dev_log/dev/homholueng_202109231453.yaml
@@ -1,0 +1,3 @@
+bugfix:
+  - 修复 operate_node API 不修改参数重试 engine v2 失败节点时节点数据会被清空的问题
+

--- a/gcloud/taskflow3/domains/dispatchers/node.py
+++ b/gcloud/taskflow3/domains/dispatchers/node.py
@@ -74,7 +74,10 @@ class NodeCommandDispatcher(EngineCommandDispatcher):
 
     @ensure_return_is_dict
     def retry_v2(self, operator: str, **kwargs) -> dict:
-        return bamboo_engine_api.retry_node(runtime=BambooDjangoRuntime(), node_id=self.node_id, data=kwargs["inputs"])
+        # 数据为空的情况传入 None, v2 engine api 不认为 {} 是空数据
+        return bamboo_engine_api.retry_node(
+            runtime=BambooDjangoRuntime(), node_id=self.node_id, data=kwargs["inputs"] or None
+        )
 
     @ensure_return_is_dict
     def skip_v1(self, operator: str, **kwargs) -> dict:


### PR DESCRIPTION
bugfix: 修复 operate_node API 不修改参数重试 engine v2 失败节点时节点数据会被清空的问题