### PR TITLE
审批插件支持在标准运维页面上也进行审批 (#4718)

### DIFF
--- a/api/collections/itsm.py
+++ b/api/collections/itsm.py
@@ -17,6 +17,8 @@ import env
 from api.client import BKComponentClient
 
 ITSM_API_ENTRY = env.BK_ITSM_API_ENTRY or "{}/{}".format(settings.BK_PAAS_ESB_HOST, "api/c/compapi/v2/itsm")
+NEED_PROCESSORS_ACTION_TYPE = ["DISTRIBUTE", "DELIVER"]
+NEED_ACTION_MESSAGE_ACTION_TYPE = ["DELIVER", "TERMINATE"]
 
 
 def _get_itsm_api(api_name):
@@ -34,4 +36,28 @@ class BKItsmClient(BKComponentClient):
                 "fast_approval": fast_approval,
                 "meta": meta,
             },
+        )
+
+    def operate_node(self, sn, operator, state_id, action_type, fields=None, processors_type=None, processors=None,
+                     action_message=None):
+        data = {
+            "sn": sn,
+            "operator": operator,
+            "state_id": state_id,
+            "action_type": action_type,
+        }
+
+        if action_type == "TRANSITION":
+            data["fields"] = fields
+        elif action_type in NEED_PROCESSORS_ACTION_TYPE:
+            data["processors_type"] = processors_type
+            data["processors"] = processors
+
+        if action_type in NEED_ACTION_MESSAGE_ACTION_TYPE:
+            data["action_message"] = action_message
+
+        return self._request(
+            method="post",
+            url=_get_itsm_api("operate_node"),
+            data=data
         )

--- a/pipeline_plugins/components/query/sites/open/itsm.py
+++ b/pipeline_plugins/components/query/sites/open/itsm.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from django.conf.urls import url
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from rest_framework.views import APIView
+from rest_framework import permissions, serializers
+
+from api.collections.itsm import BKItsmClient
+from gcloud.utils.handlers import handle_api_error
+
+logger = logging.getLogger("root")
+
+# 审批状态对应审批结果value
+TRANSITION_MAP = {True: "TONGYI", False: "JUJUE"}
+
+
+class ITSMViewRequestSerializer(serializers.Serializer):
+    sn = serializers.CharField(help_text="单号")
+    state_id = serializers.IntegerField(help_text="节点ID，必须是当前可处理的节点")
+    is_passed = serializers.BooleanField(help_text="是否通过")
+    message = serializers.CharField(help_text="审批备注", allow_blank=True)
+
+
+class ITSMViewResponse(serializers.Serializer):
+    result = serializers.BooleanField(read_only=True, help_text="请求结果")
+    message = serializers.CharField(read_only=True, help_text="请求结果失败时返回信息")
+
+
+class ITSMNodeTransitionView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    @swagger_auto_schema(
+        method="POST", operation_summary="提供节点审批功能", request_body=ITSMViewRequestSerializer,
+        responses={200: ITSMViewResponse},
+    )
+    @action(methods=["POST"], detail=False)
+    def post(self, request):
+        # 获取请求中的参数并判断
+        operator = request.user.username
+        serializer = ITSMViewRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        # 创建client并获取序列化器数据
+        client = BKItsmClient(username=operator)
+        serializer_data = serializer.data
+
+        # 构建审批表单字段列表参数
+        fields = [
+            {
+                "key": "SHENPIJIEGUO",
+                "value": TRANSITION_MAP[serializer_data["is_passed"]]
+            },
+            {
+                "key": "SHENPIBEIZHU",
+                "value": serializer_data["message"]
+            }
+        ]
+
+        # 构建请求参数
+        kwargs = {
+            "operator": operator,
+            "sn": serializer_data["sn"],
+            "state_id": serializer_data["state_id"],
+            "action_type": "TRANSITION",
+            "fields": fields
+        }
+        itsm_result = client.operate_node(**kwargs)
+
+        # 判断api请求结果是否成功
+        if not itsm_result["result"]:
+            message = handle_api_error("itsm", "node_transition", kwargs, itsm_result)
+            logger.error(message)
+            result = {"result": False, "message": message}
+            return Response(result)
+
+        return Response({"result": True, "data": None})
+
+
+itsm_urlpatterns = [
+    url(r"^itsm/node_transition/$", ITSMNodeTransitionView.as_view())
+]

--- a/pipeline_plugins/components/query/sites/open/query.py
+++ b/pipeline_plugins/components/query/sites/open/query.py
@@ -13,12 +13,14 @@ specific language governing permissions and limitations under the License.
 
 from pipeline_plugins.components.query.sites.open.cc import cc_urlpatterns
 from pipeline_plugins.components.query.sites.open.file_upload import file_upload_urlpatterns
+from pipeline_plugins.components.query.sites.open.itsm import itsm_urlpatterns
 from pipeline_plugins.components.query.sites.open.job import job_urlpatterns
-from pipeline_plugins.components.query.sites.open.nodeman import nodeman_urlpatterns
 from pipeline_plugins.components.query.sites.open.monitor import monitor_urlpatterns
+from pipeline_plugins.components.query.sites.open.nodeman import nodeman_urlpatterns
 
 urlpatterns = cc_urlpatterns
 urlpatterns += file_upload_urlpatterns
 urlpatterns += job_urlpatterns
 urlpatterns += nodeman_urlpatterns
 urlpatterns += monitor_urlpatterns
+urlpatterns += itsm_urlpatterns


### PR DESCRIPTION
* optimization: 审批插件支持在标准运维页面上也进行审批

* minor: 由于data返回为空,取消结果序列化器中的定义